### PR TITLE
Add VSCode Run and Debug Files

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,33 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "HostedFidoApi",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build-hostedFidoApi",
+      "program": "${workspaceFolder}/HostedFidoApi/bin/Debug/net7.0/HostedFidoApi.dll",
+      "args": [],
+      "cwd": "${workspaceFolder}/HostedFidoApi",
+      "stopAtEntry": false,
+      "serverReadyAction": {
+        "action": "openExternally",
+        "pattern": "\\bNow listening on:\\s+(https?://\\S+)"
+      },
+      "env": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "sourceFileMap": {
+        "/Views": "${workspaceFolder}/Views"
+      }
+    },
+    {
+      "name": ".NET Core Attach",
+      "type": "coreclr",
+      "request": "attach"
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,41 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "build-hostedFidoApi",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "build",
+        "${workspaceFolder}/HostedFidoApi/HostedFidoApi.csproj",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "publish",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "publish",
+        "${workspaceFolder}/HostedFidoApi/HostedFidoApi.csproj",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "watch",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "watch",
+        "run",
+        "--project",
+        "${workspaceFolder}/HostedFidoApi/HostedFidoApi.csproj"
+      ],
+      "problemMatcher": "$msCompile"
+    }
+  ]
+}


### PR DESCRIPTION
Add VSCode `launch.json` and `tasks.json` files so that it is easier to debug in VSCode. I just let VSCode autogenerate these files and just changed a couple of names to make it easier to read. 

NOTE: `launch.json` has a hardcoded reference to the .NET version so whenever the target framework of the project is bumped this will have to be as well for debugging to continue to work. 