### PR TITLE
Auto Pack and Publish Packages

### DIFF
--- a/.github/workflows/test-and-format.yml
+++ b/.github/workflows/test-and-format.yml
@@ -50,8 +50,13 @@ jobs:
           reporter: dotnet-trx
           fail-on-error: true
 
+      - name: Clean Branch Name
+        run: echo "CLEAN_BRANCH_NAME=${BRANCH_NAME/\//-}" >> $GITHUB_ENV
+        env:
+          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+
       - name: Pack NuGet Packages
-        run: dotnet pack --no-build --include-symbols --include-source --configuration Release --version-suffix "ci-${{ github.ref_name}}-${{ github.run_id }}"
+        run: dotnet pack --no-build --include-symbols --include-source --configuration Release --version-suffix "ci-${{ env.CLEAN_BRANCH_NAME }}-${{ github.run_id }}"
       
       - name: Publish NuGet Packages
         run: dotnet nuget push **/*.nupkg --source https://nuget.pkg.github.com/passwordless/index.json --api-key ${GITHUB_TOKEN}

--- a/.github/workflows/test-and-format.yml
+++ b/.github/workflows/test-and-format.yml
@@ -28,15 +28,19 @@ jobs:
       # You can test your matrix by printing the current dotnet version
       - name: Display dotnet version
         run: dotnet --version
+
       - name: Install dependencies
         run: dotnet restore --locked-mode
-      
+
       - name: Build
-        run: dotnet build --verbosity minimal
-      
+        run: dotnet build --verbosity minimal --no-restore
+
+      - name: Check Format
+        run: dotnet format --verify-no-changes --no-restore
+
       - name: Test with the dotnet CLI
-        run: dotnet test --no-build --logger "trx;LogFileName=pw-test-results.trx"
-      
+        run: dotnet test --no-build --no-restore --logger "trx;LogFileName=pw-test-results.trx"
+
       - name: Report test results
         uses: dorny/test-reporter@c9b3d0e2bd2a4e96aaf424dbaa31c46b42318226 # v1.6.0
         if: always()
@@ -45,6 +49,11 @@ jobs:
           path: "**/*-test-results.trx"
           reporter: dotnet-trx
           fail-on-error: true
+
+      - name: Pack NuGet Packages
+        run: dotnet pack --no-build --include-symbols --include-source --configuration Release --version-suffix "ci-${{ github.ref_name}}-${{ github.run_id }}"
       
-      - name: Check format
-        run: dotnet format --verify-no-changes
+      - name: Publish NuGet Packages
+        run: dotnet nuget push **/*.nupkg --source https://nuget.pkg.github.com/passwordless/index.json --api-key ${GITHUB_TOKEN}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-and-format.yml
+++ b/.github/workflows/test-and-format.yml
@@ -19,9 +19,6 @@ jobs:
     #   matrix:
     #     dotnet-version: [ '3.1.x', '6.0.x' ]
 
-    permissions:
-      packages: write
-
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - name: Setup dotnet

--- a/.github/workflows/test-and-format.yml
+++ b/.github/workflows/test-and-format.yml
@@ -56,7 +56,7 @@ jobs:
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
 
       - name: Pack NuGet Packages
-        run: dotnet pack --no-build --include-symbols --include-source --configuration Release --version-suffix "ci-${{ env.CLEAN_BRANCH_NAME }}-${{ github.run_id }}"
+        run: dotnet pack --no-build --include-symbols --include-source --version-suffix "ci-${{ env.CLEAN_BRANCH_NAME }}-${{ github.run_id }}"
       
       - name: Publish NuGet Packages
         run: dotnet nuget push **/*.nupkg --source https://nuget.pkg.github.com/passwordless/index.json --api-key ${GITHUB_TOKEN}

--- a/.github/workflows/test-and-format.yml
+++ b/.github/workflows/test-and-format.yml
@@ -21,6 +21,7 @@ jobs:
 
     permissions:
       packages: write
+      checks: write
 
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
@@ -44,14 +45,14 @@ jobs:
       - name: Test with the dotnet CLI
         run: dotnet test --no-build --no-restore --logger "trx;LogFileName=pw-test-results.trx"
 
-      # - name: Report test results
-      #   uses: dorny/test-reporter@c9b3d0e2bd2a4e96aaf424dbaa31c46b42318226 # v1.6.0
-      #   if: always()
-      #   with:
-      #     name: Test Results
-      #     path: "**/*-test-results.trx"
-      #     reporter: dotnet-trx
-      #     fail-on-error: true
+      - name: Report test results
+        uses: dorny/test-reporter@c9b3d0e2bd2a4e96aaf424dbaa31c46b42318226 # v1.6.0
+        if: always()
+        with:
+          name: Test Results
+          path: "**/*-test-results.trx"
+          reporter: dotnet-trx
+          fail-on-error: true
 
       - name: Clean Branch Name
         run: echo "CLEAN_BRANCH_NAME=${BRANCH_NAME/\//-}" >> $GITHUB_ENV
@@ -59,7 +60,7 @@ jobs:
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
 
       - name: Pack NuGet Packages
-        run: dotnet pack --no-build --include-symbols --include-source --version-suffix "ci-${{ env.CLEAN_BRANCH_NAME }}-${{ github.run_id }}"
+        run: dotnet pack --no-build --include-source --version-suffix "ci-${{ env.CLEAN_BRANCH_NAME }}-${{ github.run_id }}"
       
       - name: Publish NuGet Packages
         run: dotnet nuget push **/*.nupkg --source https://nuget.pkg.github.com/passwordless/index.json --api-key ${GITHUB_TOKEN}

--- a/.github/workflows/test-and-format.yml
+++ b/.github/workflows/test-and-format.yml
@@ -44,14 +44,14 @@ jobs:
       - name: Test with the dotnet CLI
         run: dotnet test --no-build --no-restore --logger "trx;LogFileName=pw-test-results.trx"
 
-      - name: Report test results
-        uses: dorny/test-reporter@c9b3d0e2bd2a4e96aaf424dbaa31c46b42318226 # v1.6.0
-        if: always()
-        with:
-          name: Test Results
-          path: "**/*-test-results.trx"
-          reporter: dotnet-trx
-          fail-on-error: true
+      # - name: Report test results
+      #   uses: dorny/test-reporter@c9b3d0e2bd2a4e96aaf424dbaa31c46b42318226 # v1.6.0
+      #   if: always()
+      #   with:
+      #     name: Test Results
+      #     path: "**/*-test-results.trx"
+      #     reporter: dotnet-trx
+      #     fail-on-error: true
 
       - name: Clean Branch Name
         run: echo "CLEAN_BRANCH_NAME=${BRANCH_NAME/\//-}" >> $GITHUB_ENV

--- a/.github/workflows/test-and-format.yml
+++ b/.github/workflows/test-and-format.yml
@@ -19,6 +19,9 @@ jobs:
     #   matrix:
     #     dotnet-version: [ '3.1.x', '6.0.x' ]
 
+    permissions:
+      packages: write
+
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - name: Setup dotnet

--- a/.github/workflows/test-and-format.yml
+++ b/.github/workflows/test-and-format.yml
@@ -60,7 +60,7 @@ jobs:
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
 
       - name: Pack NuGet Packages
-        run: dotnet pack --no-build --include-source --version-suffix "ci-${{ env.CLEAN_BRANCH_NAME }}-${{ github.run_id }}"
+        run: dotnet pack --no-build --version-suffix "ci-${{ env.CLEAN_BRANCH_NAME }}-${{ github.run_id }}"
       
       - name: Publish NuGet Packages
         run: dotnet nuget push **/*.nupkg --source https://nuget.pkg.github.com/passwordless/index.json --api-key ${GITHUB_TOKEN}

--- a/src/ApiHelpers/ApiHelpers.csproj
+++ b/src/ApiHelpers/ApiHelpers.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Nullable>disable</Nullable>
     <ImplicitUsings>false</ImplicitUsings>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AspNetCore/AspNetCore.csproj
+++ b/src/AspNetCore/AspNetCore.csproj
@@ -8,6 +8,7 @@
     <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <VersionPrefix>0.0.10</VersionPrefix>
   </PropertyGroup>
 
   <!-- 

--- a/src/Sdk/Sdk.csproj
+++ b/src/Sdk/Sdk.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <RootNamespace>Passwordless.Net</RootNamespace>
     <AssemblyName>Passwordless.Net</AssemblyName>
+    <VersionPrefix>0.0.10</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Service/Service.csproj
+++ b/src/Service/Service.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Pack and publish a version of the `Passwordless.AspNetCore` and `Passwordless.Net` packages on each run of CI that also includes branch name. This way you can target `<PackageReference Include="Passwordless.Net" Version="0.0.10-ci-main-*" />` if you want the latest from `main` or you can target your own feature branch.