### PR TITLE
Add CI/CD

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -1,0 +1,67 @@
+---
+name: _build
+run-name: Build - ${{ inputs.project-name }}
+
+on:
+  workflow_call:
+    inputs:
+      project-name:
+        type: string
+        required: true
+      project-path:
+        type: string
+        required: true
+      version:
+        type: string
+        required: true
+
+jobs:
+  build:
+    name: Build ${{ inputs.project-name }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Get pinned .NET version
+        id: dotnet-version
+        run: echo "value=$(cat global.json | jq -r '.sdk.version')" >> $GITHUB_OUTPUT
+
+      - name: Set up dotnet
+        uses: actions/setup-dotnet@9211491ffb35dd6a6657ca4f45d43dfe6e97c829  # v2.0.0
+        with:
+          dotnet-version: ${{ steps.dotnet-version.outputs.value }}
+
+      - name: Checkout Repo
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab  # v3.5.2
+        with:
+          fetch-depth: 0
+
+      - name: Install dependencies
+        run: dotnet restore --locked-mode
+
+      - name: Build
+        run: dotnet build --verbosity minimal
+
+      - name: .NET Clean & Restore
+        run: |
+          echo "Clean"
+          dotnet clean
+          echo "Restore"
+          dotnet restore --runtime win-x86  # Does this need to run in --locked-mode too?
+      - name: .NET Publish ${{ inputs.project-name }}
+        run: |
+          echo "Publish"
+          dotnet publish ${{ inputs.project-path }}/${{ inputs.project-name }}.csproj \
+            -c Release --no-restore --runtime win-x86 --no-self-contained \
+            -o ./tmp/publish-${{ inputs.project-name }} -p:Version=${{ inputs.version }}
+      - name: Zip ${{ inputs.project-name }} Artifact
+        run: |
+          cd ./tmp/publish-${{ inputs.project-name }}
+          zip -r ${{ inputs.project-name }}.zip .
+          mv ${{ inputs.project-name }}.zip ../../
+          pwd
+          ls -atlh ../../
+      - name: Upload project artifact
+        uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535  # v3.0.0
+        with:
+          name: ${{ inputs.project-name }}.zip
+          path: ./${{ inputs.project-name }}.zip
+          if-no-files-found: error

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -46,12 +46,14 @@ jobs:
           dotnet clean
           echo "Restore"
           dotnet restore --runtime win-x86  # Does this need to run in --locked-mode too?
+
       - name: .NET Publish ${{ inputs.project-name }}
         run: |
           echo "Publish"
           dotnet publish ${{ inputs.project-path }}/${{ inputs.project-name }}.csproj \
             -c Release --no-restore --runtime win-x86 --no-self-contained \
             -o ./tmp/publish-${{ inputs.project-name }} -p:Version=${{ inputs.version }}
+
       - name: Zip ${{ inputs.project-name }} Artifact
         run: |
           cd ./tmp/publish-${{ inputs.project-name }}
@@ -59,6 +61,7 @@ jobs:
           mv ${{ inputs.project-name }}.zip ../../
           pwd
           ls -atlh ../../
+
       - name: Upload project artifact
         uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535  # v3.0.0
         with:

--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -1,0 +1,49 @@
+---
+name: _deploy
+run-name: Deploy to ${{ inputs.environment }}
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        type: string
+        required: true
+        description: "Environment to deploy to"
+      project-name:
+        type: string
+        required: true
+        description: "Name of the project to deploy"
+      is-dry-run:
+        type: boolean
+        default: true
+      version:
+        type: string
+        required: true
+
+jobs:
+  deploy:
+    name: Deploy ${{ inputs.project-name }} to ${{ inputs.environment }}
+    runs-on: ubuntu-22.04
+    environment: ${{ inputs.environment }}-${{ inputs.project-name }}
+    concurrency: ${{ inputs.environment }}-${{ inputs.project-name }}
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a  # v3.0.2
+        with:
+          name: ${{ inputs.project-name }}.zip
+
+      - name: Login to Azure
+        if: ${{ ! inputs.is-dry-run }}
+        uses: Azure/login@1f63701bf3e6892515f1b7ce2d2bf1708b46beaf  # v1.4.3
+        with:
+          creds: ${{ secrets.APP_SERVICE_SP }}  # From the environment.secrets
+
+      - name: Configure & Deploy App
+        if: ${{ ! inputs.is-dry-run }}
+        run: |
+          az webapp config appsettings set -g ${{ secrets.AZURE_RESOURCE_GROUP_NAME }} \
+            -n ${{ secrets.AZURE_APP_NAME }} --slot staging \
+            --settings DD_VERSION=${{ inputs.version }}
+          az webapp deployment source config-zip \
+            --resource-group ${{ secrets.AZURE_RESOURCE_GROUP_NAME }} \
+            --name ${{ secrets.AZURE_APP_NAME }} --slot staging --src ./${{ inputs.project-name }}.zip

--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -1,0 +1,49 @@
+---
+name: _release
+run-name: Release - ${{ inputs.version }}
+
+on:
+  workflow_call:
+    inputs:
+      is-dry-run:
+        type: boolean
+        default: true
+      version:
+        type: string
+        required: true
+jobs:
+  release:
+    name: Release ${{ inputs.version }}
+    runs-on: ubuntu-22.04
+    env:
+      _BOT_EMAIL: 106330231+bitwarden-devops-bot@users.noreply.github.com
+      _BOT_NAME: bitwarden-devops-bot
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab  # v3.5.2
+        with:
+          fetch-depth: 0
+
+      - name: Download artifact
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a  # v3.0.2
+        with:
+          name: Api.zip
+
+      - name: Download artifact
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a  # v3.0.2
+        with:
+          name: AdminConsole.zip
+
+      - name: Create release
+        if: ${{ ! inputs.is-dry-run }}
+        uses: ncipollo/release-action@a2e71bdd4e7dab70ca26a852f29600c98b33153e  # v1.12.0
+        with:
+          artifacts: "Api.zip,
+            AdminConsole.zip"
+          commit: ${{ github.sha }}
+          tag: "${{ inputs.version }}"
+          name: "Version ${{ inputs.version }}"
+          body: "<insert release notes here>"
+          generateReleaseNotes: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          draft: true

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -1,0 +1,46 @@
+---
+name: _test
+run-name: Test & Format
+
+on:
+  workflow_call: {}
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Get pinned .NET version
+        id: dotnet-version
+        run: echo "value=$(cat global.json | jq -r '.sdk.version')" >> $GITHUB_OUTPUT
+
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@607fce577a46308457984d59e4954e075820f10a  # v3.0.3
+        with:
+          dotnet-version: ${{ steps.dotnet-version.outputs.value }}
+
+      - name: Display dotnet version
+        run: dotnet --version
+
+      - name: Checkout Repo
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c  # v3.3.0
+
+      - name: Check format
+        run: dotnet format --verify-no-changes
+
+      - name: Install dependencies
+        run: dotnet restore --locked-mode
+
+      - name: Build
+        run: dotnet build --verbosity minimal
+
+      - name: Test with the dotnet CLI
+        run: dotnet test --no-build --logger "trx;LogFileName=pw-test-results.trx"
+
+      - name: Report test results
+        uses: dorny/test-reporter@c9b3d0e2bd2a4e96aaf424dbaa31c46b42318226  # v1.6.0
+        if: always()
+        with:
+          name: Test Results
+          path: "**/*-test-results.trx"
+          reporter: dotnet-trx
+          fail-on-error: true

--- a/.github/workflows/_version.yml
+++ b/.github/workflows/_version.yml
@@ -1,0 +1,48 @@
+---
+name: _version
+run-name: Calculate Version
+
+on:
+  workflow_call:
+    inputs:
+      is-release:
+        type: boolean
+        default: false
+    outputs:
+      version:
+        description: "version to be built"
+        value: ${{ jobs.version.outputs.version }}
+
+jobs:
+  version:
+    name: Calculate Version
+    runs-on: ubuntu-22.04
+    outputs:
+      version: ${{ steps.version.outputs.value }}
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab  # v3.5.2
+        with:
+          fetch-depth: 0
+
+      - name: Generate Version
+        id: version
+        run: |
+          git fetch --prune --tags
+
+          echo "Calculating next version..."
+          base_version=$(cat Directory.Build.props |
+            grep -o "<BaseVersion>.*</BaseVersion>" |
+            grep -Eo "[0-9]+\.[0-9]+"
+          )
+          latest_tag_version=$(git tag --sort=committerdate --list | tail -1)
+          echo "  latest_tag_version: $latest_tag_version"
+          version_suffix=$((${latest_tag_version##*.} + 1))
+
+          if [[ "${{ inputs.is-release }}" == "false" ]]; then
+            version_suffix=$version_suffix-${GITHUB_SHA:0:7}
+          fi
+
+          echo "  version: $base_version.$version_suffix"
+          echo "value=$base_version.$version_suffix" >> $GITHUB_OUTPUT
+          echo "Done"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,56 @@
+---
+name: CD
+
+on:
+  workflow_dispatch:
+    inputs: {}
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  deployments: write
+  id-token: write
+  checks: write
+
+jobs:
+  version:
+    uses: ./.github/workflows/_version.yml
+
+
+  test:
+    uses: ./.github/workflows/_test.yml
+
+
+  build:
+    needs:
+      - test
+      - version
+    strategy:
+      matrix:
+        project-name:
+          - AdminConsole
+          - Api
+    uses: ./.github/workflows/_build.yml
+    with:
+      project-name: ${{ matrix.project-name }}
+      project-path: ./src/${{ matrix.project-name }}
+      version: ${{ needs.version.outputs.version }}
+
+
+  deploy-devtest:
+    strategy:
+      matrix:
+        project-name:
+          - AdminConsole
+          - Api
+    needs:
+      - build
+      - version
+    uses: ./.github/workflows/_deploy.yml
+    secrets: inherit
+    with:
+      environment: devtest
+      project-name: ${{ matrix.project-name }}
+      version: ${{ needs.version.outputs.version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+---
+name: CI
+
+on:
+  workflow_dispatch:
+    inputs: {}
+  push:
+    branches-ignore:
+      - main
+
+permissions:
+  id-token: write
+  contents: read
+  checks: write
+
+jobs:
+  version:
+    uses: ./.github/workflows/_version.yml
+
+
+  test:
+    uses: ./.github/workflows/_test.yml
+
+
+  build:
+    needs:
+      - test
+      - version
+    strategy:
+      matrix:
+        project-name:
+          - AdminConsole
+          - Api
+    uses: ./.github/workflows/_build.yml
+    with:
+      project-name: ${{ matrix.project-name }}
+      project-path: ./src/${{ matrix.project-name }}
+      version: ${{ needs.version.outputs.version }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,111 @@
+---
+name: Release & Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      deploy-api:
+        description: "Deploy Api"
+        type: boolean
+        default: false
+      deploy-adminconsole:
+        description: "Deploy AdminConsole"
+        type: boolean
+        default: false
+
+
+permissions:
+  contents: write
+  deployments: write
+  id-token: write
+  checks: write
+
+jobs:
+  version:
+    uses: ./.github/workflows/_version.yml
+    with:
+      is-release: true
+
+
+  test:
+    uses: ./.github/workflows/_test.yml
+
+
+  build:
+    needs:
+      - test
+      - version
+    strategy:
+      matrix:
+        project-name:
+          - AdminConsole
+          - Api
+    uses: ./.github/workflows/_build.yml
+    with:
+      project-name: ${{ matrix.project-name }}
+      project-path: ./src/${{ matrix.project-name }}
+      version: ${{ needs.version.outputs.version }}
+
+
+  release:
+    needs:
+      - build
+      - version
+    uses: ./.github/workflows/_release.yml
+    with:
+      version: ${{ needs.version.outputs.version }}
+      is-dry-run: false
+
+
+  # deploy-qa-api:
+  #   if: ${{ inputs.deploy-api }}
+  #   needs:
+  #     - build
+  #   uses: ./.github/workflows/_deploy.yml
+  #   secrets: inherit
+  #   with:
+  #     environment: qa
+  #     project-name: AdminConsole
+  #     version: ${{ needs.version.outputs.version }}
+
+
+  # deploy-qa-adminconsole:
+  #   if: ${{ inputs.deploy-adminconsole }}
+  #   needs:
+  #     - build
+  #   uses: ./.github/workflows/_deploy.yml
+  #   secrets: inherit
+  #   with:
+  #     environment: qa
+  #     project-name: AdminConsole
+  #     version: ${{ needs.version.outputs.version }}
+
+
+  deploy-prod-api:
+    if: ${{ inputs.deploy-api }}
+    needs:
+      - build
+      - version
+      - release
+      # - deploy-qa-api
+    uses: ./.github/workflows/_deploy.yml
+    secrets: inherit
+    with:
+      environment: production
+      project-name: Api
+      version: ${{ needs.version.outputs.version }}
+
+
+  deploy-prod-adminconsole:
+    if: ${{ inputs.deploy-adminconsole }}
+    needs:
+      - build
+      - version
+      - release
+      # - deploy-qa-admin-console
+    uses: ./.github/workflows/_deploy.yml
+    secrets: inherit
+    with:
+      environment: production
+      project-name: AdminConsole
+      version: ${{ needs.version.outputs.version }}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
+    <BaseVersion>1.0</BaseVersion>
     <RootNamespace Condition="$(RootNamespace) == ''">Passwordless.$(MSBuildProjectName)</RootNamespace>
     <AssemblyName Condition="$(AssemblyName) == ''">Passwordless.$(MSBuildProjectName)</AssemblyName>
     <ImplicitUsings>true</ImplicitUsings>


### PR DESCRIPTION
## Objective

Add CI/CD to support the Engineering SDLC of Passwordless.dev.


### Versioning Strategy

We are experimenting with automatic version bumping with SemVer. All version bumps default to an increment of the patch version of the latest GitHub tag. If the major or minor version is updated in the `Directory.Build.Props`, the patch version is reset to 0.


### Pushing commits

Every commit that is pushed to GitHub on all branches except for `main` has tests and test builds run to have as short of a feedback loop as possible for the engineer working on the PR.


### Merges to `main`

Every merge to `main` will run through the tests, will be built, and then automatically deployed to our DevTest Environment. This also assists in keeping the feedback loop short and helps the engineer see their code in a full environment as soon as it is accepted to `main`


### Deploys

For now, deploys to any higher environments are manually triggered from GitHub Actions. These deploys will also result in a draft GitHub Release being created with generated Release notes.