### PR TITLE
Breaking change: Uses specific value for db connection string.

### DIFF
--- a/src/AdminConsole/Db/AddDatabaseExtensionMethod.cs
+++ b/src/AdminConsole/Db/AddDatabaseExtensionMethod.cs
@@ -7,11 +7,8 @@ public static class AddDatabaseExtensionMethod
     public static IServiceCollection AddDatabase(this IServiceCollection services, WebApplicationBuilder builder)
     {
         // if not present, try use sqlite
-        var sqlite = builder.Configuration.GetConnectionString("sqlite");
-        var mssql = builder.Configuration.GetConnectionString("mssql");
-
-        sqlite = builder.Configuration.GetValue<string>("ConnectionStrings:Sqlite:Admin", sqlite);
-        mssql = builder.Configuration.GetValue<string>("ConnectionStrings:Mssql:Admin", mssql);
+        var sqlite = builder.Configuration.GetConnectionString("sqlite:admin");
+        var mssql = builder.Configuration.GetConnectionString("mssql:admin");
 
         // read "migrate_db" from env
         var migrating = builder.Configuration.GetValue<string>("ef_migrate");

--- a/src/AdminConsole/Db/MssqlConsoleDbContext.cs
+++ b/src/AdminConsole/Db/MssqlConsoleDbContext.cs
@@ -13,7 +13,7 @@ public class MssqlConsoleDbContext : ConsoleDbContext
     }
 
     protected override void OnConfiguring(DbContextOptionsBuilder options)
-        => options.UseSqlServer(_config.GetConnectionString("mssql"));
+        => options.UseSqlServer(_config.GetConnectionString("mssql:admin"));
 }
 
 // public class MssqlContextFactory : IDesignTimeDbContextFactory<MssqlConsoleDbContext>

--- a/src/AdminConsole/Db/SqliteConsoleDbContext.cs
+++ b/src/AdminConsole/Db/SqliteConsoleDbContext.cs
@@ -13,5 +13,5 @@ public class SqliteConsoleDbContext : ConsoleDbContext
     }
 
     protected override void OnConfiguring(DbContextOptionsBuilder options)
-        => options.UseSqlite(_config.GetConnectionString("sqlite"));
+        => options.UseSqlite(_config.GetConnectionString("sqlite:admin"));
 }

--- a/src/AdminConsole/appsettings.Development.json
+++ b/src/AdminConsole/appsettings.Development.json
@@ -11,7 +11,7 @@
     "CustomerAuthPlanName": "Professional Test"    
   },
   "ConnectionStrings": {
-    "sqlite": "Data Source=adminconsole_dev.db"
+    "sqlite:admin": "Data Source=adminconsole_dev.db"
   },
   "Passwordless": {
     "ApiUrl": "http://localhost:7001",

--- a/src/AdminConsole/appsettings.Development.json
+++ b/src/AdminConsole/appsettings.Development.json
@@ -11,7 +11,9 @@
     "CustomerAuthPlanName": "Professional Test"    
   },
   "ConnectionStrings": {
-    "sqlite:admin": "Data Source=adminconsole_dev.db"
+    "sqlite": {
+      "admin": "Data Source=adminconsole_dev.db"
+    }
   },
   "Passwordless": {
     "ApiUrl": "http://localhost:7001",

--- a/src/Api/Helpers/AddDatabaseExtensionMethod.cs
+++ b/src/Api/Helpers/AddDatabaseExtensionMethod.cs
@@ -21,7 +21,8 @@ public static class AddDatabaseExtensionMethod
         {
             services.AddDbContext<DbTenantContext, SqliteContext>((sp, builder) =>
             {
-                builder.UseSqlite(sqlite);
+                
+                builder.UseSqlite(configuration.GetConnectionString("sqlite:api"));
             });
             services.AddScoped<ITenantStorageFactory, EfTenantStorageFactory<SqliteContext>>();
         }
@@ -29,7 +30,7 @@ public static class AddDatabaseExtensionMethod
         {
             services.AddDbContext<DbTenantContext, MsSqlContext>((sp, builder) =>
             {
-                builder.UseSqlServer(mssql);
+                builder.UseSqlServer(configuration.GetConnectionString("mssql:api"));
             });
             services.AddScoped<ITenantStorageFactory, EfTenantStorageFactory<MsSqlContext>>();
         }

--- a/src/Api/Helpers/AddDatabaseExtensionMethod.cs
+++ b/src/Api/Helpers/AddDatabaseExtensionMethod.cs
@@ -21,7 +21,7 @@ public static class AddDatabaseExtensionMethod
         {
             services.AddDbContext<DbTenantContext, SqliteContext>((sp, builder) =>
             {
-                
+
                 builder.UseSqlite(configuration.GetConnectionString("sqlite:api"));
             });
             services.AddScoped<ITenantStorageFactory, EfTenantStorageFactory<SqliteContext>>();

--- a/src/Api/Helpers/AddDatabaseExtensionMethod.cs
+++ b/src/Api/Helpers/AddDatabaseExtensionMethod.cs
@@ -21,8 +21,8 @@ public static class AddDatabaseExtensionMethod
         {
             services.AddDbContext<DbTenantContext, SqliteContext>((sp, builder) =>
             {
-
-                builder.UseSqlite(configuration.GetConnectionString("sqlite:api"));
+                // resolving config from SP to avoid capturing
+                builder.UseSqlite(sp.GetRequiredService<IConfiguration>().GetConnectionString("sqlite:api"));
             });
             services.AddScoped<ITenantStorageFactory, EfTenantStorageFactory<SqliteContext>>();
         }
@@ -30,7 +30,8 @@ public static class AddDatabaseExtensionMethod
         {
             services.AddDbContext<DbTenantContext, MsSqlContext>((sp, builder) =>
             {
-                builder.UseSqlServer(configuration.GetConnectionString("mssql:api"));
+                // resolving config from SP to avoid capturing
+                builder.UseSqlServer(sp.GetRequiredService<IConfiguration>().GetConnectionString("mssql:api"));
             });
             services.AddScoped<ITenantStorageFactory, EfTenantStorageFactory<MsSqlContext>>();
         }

--- a/src/Api/Helpers/AddDatabaseExtensionMethod.cs
+++ b/src/Api/Helpers/AddDatabaseExtensionMethod.cs
@@ -14,18 +14,14 @@ public static class AddDatabaseExtensionMethod
     public static IServiceCollection AddDatabase(this IServiceCollection services, IConfiguration configuration)
     {
         // Database information
-        var sqlite = configuration.GetConnectionString("sqlite");
-        var mssql = configuration.GetConnectionString("mssql");
-
-        sqlite = configuration.GetValue<string>("ConnectionStrings:Sqlite:Api", sqlite);
-        mssql = configuration.GetValue<string>("ConnectionStrings:Mssql:Api", mssql);
+        var sqlite = configuration.GetConnectionString("sqlite:api");
+        var mssql = configuration.GetConnectionString("mssql:api");
 
         if (!string.IsNullOrEmpty(sqlite))
         {
             services.AddDbContext<DbTenantContext, SqliteContext>((sp, builder) =>
             {
-                var config = sp.GetRequiredService<IConfiguration>();
-                builder.UseSqlite(config.GetConnectionString("sqlite"));
+                builder.UseSqlite(sqlite);
             });
             services.AddScoped<ITenantStorageFactory, EfTenantStorageFactory<SqliteContext>>();
         }
@@ -33,8 +29,7 @@ public static class AddDatabaseExtensionMethod
         {
             services.AddDbContext<DbTenantContext, MsSqlContext>((sp, builder) =>
             {
-                var config = sp.GetRequiredService<IConfiguration>();
-                builder.UseSqlServer(config.GetConnectionString("mssql"));
+                builder.UseSqlServer(mssql);
             });
             services.AddScoped<ITenantStorageFactory, EfTenantStorageFactory<MsSqlContext>>();
         }

--- a/src/Api/appsettings.Development.json
+++ b/src/Api/appsettings.Development.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {    
-    "sqlite": "Data Source=passwordless_dev.db"
+    "sqlite:api": "Data Source=passwordless_dev.db"
   },
   "PasswordlessManagement": {
     "ManagementKey": "shared_dev_key"

--- a/src/Api/appsettings.Development.json
+++ b/src/Api/appsettings.Development.json
@@ -1,6 +1,8 @@
 {
   "ConnectionStrings": {    
-    "sqlite:api": "Data Source=passwordless_dev.db"
+    "sqlite": {
+      "api": "Data Source=passwordless_dev.db"
+     }
   },
   "PasswordlessManagement": {
     "ManagementKey": "shared_dev_key"

--- a/tests/Api.IntegrationTests/TestWebApplicationFactory.cs
+++ b/tests/Api.IntegrationTests/TestWebApplicationFactory.cs
@@ -23,7 +23,7 @@ public class TestWebApplicationFactory<TProgram>
             config.Sources.Clear();
             config.AddInMemoryCollection(new[]
             {
-                new KeyValuePair<string, string?>("ConnectionStrings:sqlite", $"Data Source=test_{DbName}.db"),
+                new KeyValuePair<string, string?>("ConnectionStrings:sqlite:api", $"Data Source=test_{DbName}.db"),
                 new KeyValuePair<string, string?>("PasswordlessManagement:ManagementKey", "dev_test_key"),
                 new KeyValuePair<string, string?>("SALT_TOKEN", "YWJj"),
             });


### PR DESCRIPTION
Two motivations:
* Simplify to only have one config value to decide connection string
* Bug: We didn't properly use our new values