### PR TITLE
Added FluentValidation. Added rule for max length on Nickname. Added …

### DIFF
--- a/src/Api/Api.csproj
+++ b/src/Api/Api.csproj
@@ -17,6 +17,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Datadog.Trace" Version="2.30.0" />
+    <PackageReference Include="FluentValidation" Version="11.6.0" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.6.0" />
     <PackageReference Include="MessagePackAnalyzer" Version="2.5.108">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/Api/Program.cs
+++ b/src/Api/Program.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using System.Text.Json;
+using FluentValidation;
 using Microsoft.EntityFrameworkCore;
 using Passwordless.Api;
 using Passwordless.Api.Authorization;
@@ -75,6 +76,9 @@ services.AddTransient<ISharedManagementService, SharedManagementService>();
 services.AddScoped<UserCredentialsService>();
 services.AddScoped<IFido2ServiceFactory, DefaultFido2ServiceFactory>();
 services.AddScoped<ITokenService, TokenService>();
+
+services.AddValidatorsFromAssemblyContaining<Program>();
+
 services.AddSingleton(sp =>
     // TODO: Remove this and use proper Ilogger<YourType>
     sp.GetRequiredService<ILoggerFactory>().CreateLogger("NonTyped"));

--- a/src/Api/Validators/RegistrationCompleteDTOValidator.cs
+++ b/src/Api/Validators/RegistrationCompleteDTOValidator.cs
@@ -1,0 +1,12 @@
+using FluentValidation;
+using Passwordless.Service.Models;
+
+namespace Passwordless.Api.Validators;
+
+public class RegistrationCompleteDTOValidator : AbstractValidator<RegistrationCompleteDTO>
+{
+    public RegistrationCompleteDTOValidator()
+    {
+        RuleFor(x => x.Nickname).MaximumLength(255);
+    }
+}


### PR DESCRIPTION
Added FluentValidation. Added max length rule to Nickname on RegistrationCompleteDTO model.

I've worked with FluentValidation before and enjoy it more than DataAnnotations. We could add more to this and have the validation automatically take place through model binding.  I also added an additional exception block to `FriendlyExceptionsMiddleware` to handle the validation exceptions which will provide a list of invalid properties to any API caller.