### PR TITLE
PAS90: Users List should have empty value for column LastSeenAt

### DIFF
--- a/src/AdminConsole/AdminConsole.csproj
+++ b/src/AdminConsole/AdminConsole.csproj
@@ -48,7 +48,6 @@
         <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="7.0.3" />
         <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="7.0.3" />
         <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="7.0.4" />
-        <PackageReference Include="Passwordless" Version="0.0.11-beta1" />
         <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />
         <PackageReference Include="Serilog.Enrichers.Environment" Version="2.2.0" />
         <PackageReference Include="Serilog.Sinks.Datadog.Logs" Version="0.5.2" />

--- a/src/AdminConsole/Pages/App/Credentials/List.cshtml
+++ b/src/AdminConsole/Pages/App/Credentials/List.cshtml
@@ -29,7 +29,12 @@
               </td>
               <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">(@user.AliasCount) @String.Join(", ", @user.Aliases?.Where(a => !String.IsNullOrEmpty(a)) ?? Array.Empty<string>())</td>
               <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">@user.CredentialsCount</td>
-              <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500"><local-time datetime="@user.LastUsedAt.ToLocalTime()"></local-time></td>
+                <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
+                    @if (user.LastUsedAt.HasValue)
+                    {
+                        <local-time datetime="@user.LastUsedAt.Value.ToLocalTime()"></local-time>
+                    }
+                </td>
             </tr>
               }
             @if (Model.Users.Count == 0)

--- a/src/AspNetCore/AspNetCore.csproj
+++ b/src/AspNetCore/AspNetCore.csproj
@@ -23,7 +23,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Passwordless" Version="0.0.11-beta1" />
+    <PackageReference Include="Passwordless" Version="0.0.13" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.5.0" />
   </ItemGroup>
 

--- a/src/Service/UserCredentialsService.cs
+++ b/src/Service/UserCredentialsService.cs
@@ -67,5 +67,5 @@ public class UserSummary
     public int AliasCount { get; set; }
     public List<string> Aliases { get; set; }
     public int CredentialsCount { get; set; }
-    public DateTime LastUsedAt { get; set; }
+    public DateTime? LastUsedAt { get; set; }
 }


### PR DESCRIPTION
- Users list should have empty value for column 'Last Seen At' or 'Last Used at' instead of showing DateTime.MinValue
- Bumped NuGet version to 0.0.13 ([requires PR to be approved and NuGet to be published](https://github.com/passwordless/passwordless-dotnet/pull/10))