### PR TITLE
Refactoring & cleanup of options pattern.

### DIFF
--- a/src/AdminConsole/AdminConsole.csproj
+++ b/src/AdminConsole/AdminConsole.csproj
@@ -127,10 +127,4 @@
         <_ContentIncludedByDefault Remove="Areas\Identity\Pages\_ViewImports.cshtml" />
         <_ContentIncludedByDefault Remove="Areas\Identity\Pages\_ViewStart.cshtml" />
     </ItemGroup>
-    <ItemGroup>
-      <Content Remove="Pages\Shared\_TextField.cshtml" />
-    </ItemGroup>
-    <ItemGroup>
-      <Compile Remove="Pages\Shared\_TextField.cs" />
-    </ItemGroup>
 </Project>

--- a/src/AdminConsole/AdminConsole.csproj
+++ b/src/AdminConsole/AdminConsole.csproj
@@ -127,4 +127,10 @@
         <_ContentIncludedByDefault Remove="Areas\Identity\Pages\_ViewImports.cshtml" />
         <_ContentIncludedByDefault Remove="Areas\Identity\Pages\_ViewStart.cshtml" />
     </ItemGroup>
+    <ItemGroup>
+      <Content Remove="Pages\Shared\_TextField.cshtml" />
+    </ItemGroup>
+    <ItemGroup>
+      <Compile Remove="Pages\Shared\_TextField.cs" />
+    </ItemGroup>
 </Project>

--- a/src/AdminConsole/Configuration/PasswordlessClientOptions.cs
+++ b/src/AdminConsole/Configuration/PasswordlessClientOptions.cs
@@ -1,9 +1,0 @@
-using Passwordless.Net;
-
-namespace Passwordless.AdminConsole;
-
-public class PasswordlessClientOptions
-{
-    public string ApiKey { get; set; } = null!;
-    public string ApiUrl { get; set; } = PasswordlessOptions.CloudApiUrl;
-}

--- a/src/AdminConsole/Pages/Account/Login.cshtml
+++ b/src/AdminConsole/Pages/Account/Login.cshtml
@@ -4,7 +4,7 @@
 @using Microsoft.AspNetCore.Mvc.TagHelpers
 @using Microsoft.Extensions.Options
 @model LoginModel
-@inject IOptions<PasswordlessClientOptions> PasswordlessOptions
+@inject IOptions<PasswordlessOptions> PasswordlessOptions
 @inject IAntiforgery Antiforgery
 @attribute [AllowAnonymous]
 

--- a/src/AdminConsole/Pages/Account/Profile.cshtml
+++ b/src/AdminConsole/Pages/Account/Profile.cshtml
@@ -1,7 +1,7 @@
 @page
 @using Microsoft.AspNetCore.Antiforgery
 @model Profile
-@inject IOptions<PasswordlessClientOptions> PasswordlessClientOptions
+@inject IOptions<PasswordlessOptions> PasswordlessClientOptions
 @inject IAntiforgery Antiforgery
 
 @{

--- a/src/AdminConsole/Pages/Account/UserOnboarding.cshtml
+++ b/src/AdminConsole/Pages/Account/UserOnboarding.cshtml
@@ -1,7 +1,6 @@
 @page
-@using Microsoft.Extensions.Options
 @using AdminConsole.Pages.Components.ManagePasskeys
-@inject IOptions<PasswordlessClientOptions> Options
+@inject IOptions<PasswordlessOptions> Options
 @model UserOnboarding
 
 @{

--- a/src/AdminConsole/Pages/App/Credentials/User.cshtml
+++ b/src/AdminConsole/Pages/App/Credentials/User.cshtml
@@ -1,8 +1,7 @@
 ﻿@page "/credentials/user/{userid}"
 @model UserModel
-@inject IOptions<PasswordlessClientOptions> Options
+@inject IOptions<PasswordlessOptions> Options
 @inject ICurrentContext CurrentContext
-@using Passwordless.Net
 
 @{
   ViewData["Title"] = "User Details";

--- a/src/AdminConsole/Pages/App/Playground/Client.cshtml
+++ b/src/AdminConsole/Pages/App/Playground/Client.cshtml
@@ -2,7 +2,7 @@
 @using Microsoft.AspNetCore.Antiforgery
 @model ClientModel
 @inject ICurrentContext CurrentContext
-@inject IOptions<PasswordlessClientOptions> Options
+@inject IOptions<PasswordlessOptions> Options
 @inject IAntiforgery Antiforgery
 
 @{

--- a/src/AdminConsole/Pages/App/Playground/NewAccount.cshtml
+++ b/src/AdminConsole/Pages/App/Playground/NewAccount.cshtml
@@ -1,7 +1,7 @@
 @page "/playground/new-account"
 @model NewAccountModel
 @inject ICurrentContext CurrentContext
-@inject IOptions<PasswordlessClientOptions> Options
+@inject IOptions<PasswordlessOptions> Options
 @inject Microsoft.AspNetCore.Antiforgery.IAntiforgery Antiforgery
 
 @{

--- a/src/AdminConsole/Pages/Components/ManagePasskeys/Default.cshtml
+++ b/src/AdminConsole/Pages/Components/ManagePasskeys/Default.cshtml
@@ -1,7 +1,5 @@
-@using Microsoft.AspNetCore.Mvc.TagHelpers
-@using Microsoft.Extensions.Options
 @model PasskeysModel
-@inject IOptions<PasswordlessClientOptions> Options
+@inject IOptions<PasswordlessOptions> Options
 
 <div id="xapp" class="flex flex-col gap-10">
     {{showDetails}}

--- a/src/AdminConsole/Pages/Shared/_Layout.cshtml
+++ b/src/AdminConsole/Pages/Shared/_Layout.cshtml
@@ -3,7 +3,7 @@
 @using Microsoft.AspNetCore.Identity
 @inject SignInManager<ConsoleAdmin> signinManager
 @inject UserManager<ConsoleAdmin> UserManager
-@inject IOptions<PasswordlessClientOptions> Options
+@inject IOptions<PasswordlessOptions> Options
 @inject ICurrentContext CurrentContext
 @{
     var signedIn = signinManager.IsSignedIn(User);

--- a/src/AdminConsole/Program.cs
+++ b/src/AdminConsole/Program.cs
@@ -131,8 +131,6 @@ void RunTheApp()
     services.AddHostedService<TimedHostedService>();
     services.AddHostedService<ApplicationDeletionBackgroundService>();
 
-    services.Configure<PasswordlessClientOptions>(builder.Configuration.GetRequiredSection("Passwordless"));
-
     services.AddTransient<IScopedPasswordlessClient, ScopedPasswordlessClient>();
     services.AddHttpClient<IScopedPasswordlessClient, ScopedPasswordlessClient>((provider, client) =>
     {


### PR DESCRIPTION
We already inject PasswordlessOptions when bootstrapping the Passwordless SDK, it's pointless to have PasswordlessClientOptions.