### PR TITLE
Added Organization Audit Log Events for Admin Invites

### DIFF
--- a/src/AdminConsole/AuditLog/AuditLogEventFunctions.cs
+++ b/src/AdminConsole/AuditLog/AuditLogEventFunctions.cs
@@ -53,6 +53,24 @@ public static class AuditLogEventFunctions
             performedBy.OrganizationId,
             performedAt);
 
+    public static OrganizationEventDto AdminInvalidInviteUsedEvent(Invite invite, DateTime performedAt) =>
+        new(invite.ToEmail,
+            AuditEventType.AdminInvalidInviteUsed,
+            "Expired invite used.",
+            Severity.Warning,
+            invite.ToEmail,
+            invite.TargetOrgId,
+            performedAt);
+
+    public static OrganizationEventDto AdminAcceptedInviteEvent(Invite invite, ConsoleAdmin consoleAdmin, DateTime performedAt) =>
+        new(consoleAdmin.Id,
+            AuditEventType.AdminAcceptedInvite,
+            $"{consoleAdmin.Name} accepted invite sent to {invite.ToEmail}.",
+            Severity.Informational,
+            consoleAdmin.OrganizationId.ToString(),
+            consoleAdmin.OrganizationId,
+            performedAt);
+
     public static OrganizationAuditEvent ToNewEvent(this OrganizationEventDto dto) =>
         new()
         {

--- a/src/AdminConsole/Services/InvitationService.cs
+++ b/src/AdminConsole/Services/InvitationService.cs
@@ -53,7 +53,6 @@ public class InvitationService
         string link = urlBuilder.PageLink("/organization/join", values: new { code = Convert.ToBase64String(code) });
         // send email
         await _mailService.SendInviteAsync(inv, link);
-
     }
 
     private string HashCode(byte[] code)

--- a/src/Common/AuditLog/Enums/AuditEventType.cs
+++ b/src/Common/AuditLog/Enums/AuditEventType.cs
@@ -22,4 +22,6 @@ public enum AuditEventType
     AdminMagicLinkLogin = 7002,
     AdminDeleteAdmin = 7003,
     AdminCancelAdminInvite = 7004,
+    AdminInvalidInviteUsed = 7005,
+    AdminAcceptedInvite = 7006
 }


### PR DESCRIPTION
This includes two new events for organization audit logs. One is for when an expired invite is used and for when an admin has successfully joined the organziation.