### PR TITLE
Adding Reload and Redirect to Organization/Verify

### DIFF
--- a/src/AdminConsole/Pages/Organization/Verify.cshtml
+++ b/src/AdminConsole/Pages/Organization/Verify.cshtml
@@ -7,8 +7,8 @@
 }
 
 @section Head {
-    @* This to refresh the page to check if the user has verified and logged in *@
-    <meta http-equiv="refresh" content="15"/>
+    // This to refresh the page to check if the user has verified and logged in
+    <meta http-equiv="refresh" content="15" />
 }
 
 <p>We've sent a confirmation link to the email address you provided. Click on the link in the email to verify your account</p>

--- a/src/AdminConsole/Pages/Organization/Verify.cshtml
+++ b/src/AdminConsole/Pages/Organization/Verify.cshtml
@@ -8,6 +8,8 @@
 
 <p>We've sent a confirmation link to the email address you provided. Click on the link in the email to verify your account</p>
 
+<meta http-equiv="refresh" content="10" />
+
 <environment names="Development">
     @{
         var mailPath = System.IO.Path.GetFullPath("mail.md");

--- a/src/AdminConsole/Pages/Organization/Verify.cshtml
+++ b/src/AdminConsole/Pages/Organization/Verify.cshtml
@@ -6,16 +6,19 @@
     ViewData["Title"] = "Verify your account";
 }
 
-<p>We've sent a confirmation link to the email address you provided. Click on the link in the email to verify your account</p>
+@section Head {
+    <!-- This to refresh the page to check if the user has verified and logged in -->
+    <meta http-equiv="refresh" content="15"/>
+}
 
-<meta http-equiv="refresh" content="10" />
+<p>We've sent a confirmation link to the email address you provided. Click on the link in the email to verify your account</p>
 
 <environment names="Development">
     @{
         var mailPath = System.IO.Path.GetFullPath("mail.md");
     }
-    <br />
+    <br/>
     <b>Development mode: </b> Please open the the <code>src/AdminConsole/mail.md</code> file.
-    <br />
+    <br/>
     <a class="link-blue" href="vscode://file/@mailPath">Open with VS Code: @mailPath</a>
 </environment>

--- a/src/AdminConsole/Pages/Organization/Verify.cshtml
+++ b/src/AdminConsole/Pages/Organization/Verify.cshtml
@@ -7,7 +7,7 @@
 }
 
 @section Head {
-    <!-- This to refresh the page to check if the user has verified and logged in -->
+    @* This to refresh the page to check if the user has verified and logged in *@
     <meta http-equiv="refresh" content="15"/>
 }
 
@@ -17,8 +17,8 @@
     @{
         var mailPath = System.IO.Path.GetFullPath("mail.md");
     }
-    <br/>
+    <br>
     <b>Development mode: </b> Please open the the <code>src/AdminConsole/mail.md</code> file.
-    <br/>
+    <br>
     <a class="link-blue" href="vscode://file/@mailPath">Open with VS Code: @mailPath</a>
 </environment>

--- a/src/AdminConsole/Pages/Organization/Verify.cshtml.cs
+++ b/src/AdminConsole/Pages/Organization/Verify.cshtml.cs
@@ -7,14 +7,18 @@ namespace AdminConsole.Pages.Organization;
 public class Verify : PageModel
 {
     private readonly MagicLinkSignInManager<ConsoleAdmin> _signInManager;
+    private readonly IHttpContextAccessor _httpContextAccessor;
 
-    public Verify(MagicLinkSignInManager<ConsoleAdmin> signInManager)
+    public Verify(MagicLinkSignInManager<ConsoleAdmin> signInManager, IHttpContextAccessor httpContextAccessor)
     {
         _signInManager = signInManager;
+        _httpContextAccessor = httpContextAccessor;
     }
 
-    public async Task<IActionResult> OnGet(string token, string email)
+    public IActionResult OnGet()
     {
-        return Page();
+        return _httpContextAccessor.HttpContext != null && _signInManager.IsSignedIn(_httpContextAccessor.HttpContext.User)
+            ? RedirectToPage("/Account/useronboarding")
+            : Page();
     }
 }

--- a/src/AdminConsole/Pages/Shared/_Layout.cshtml
+++ b/src/AdminConsole/Pages/Shared/_Layout.cshtml
@@ -21,6 +21,7 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
     <link rel="manifest" href="/site.webmanifest">
+    @await RenderSectionAsync("Head", false)
 </head>
 
 <body class="h-full bg-gray-50">


### PR DESCRIPTION
This will add a 15 second reload to the /Organization/Verify page.

After the user has signed up for an account, we send them to /organization/verify/.  Here we will now refresh the page every 15 seconds and if they've clicked the link or are verified, it will redirect them to the /account/useronboarding page to set up their passkey.