### PR TITLE
Fix scheduled application deletion

### DIFF
--- a/src/AdminConsole/Services/ApplicationDeletionBackgroundService.cs
+++ b/src/AdminConsole/Services/ApplicationDeletionBackgroundService.cs
@@ -1,6 +1,5 @@
 using AdminConsole.Db;
 using AdminConsole.Models;
-using Microsoft.EntityFrameworkCore;
 
 namespace Passwordless.AdminConsole.Services;
 
@@ -49,11 +48,16 @@ public sealed class ApplicationDeletionBackgroundService : BackgroundService
             var applicationIds = await client.ListApplicationsPendingDeletionAsync();
             foreach (var applicationId in applicationIds)
             {
-                await client.DeleteApplicationAsync(applicationId);
-                var application = new Application { Id = applicationId };
-                db.Entry(application).State = EntityState.Deleted;
-                db.Applications.Remove(application);
-                await db.SaveChangesAsync();
+                if (await client.DeleteApplicationAsync(applicationId))
+                {
+                    var application = new Application { Id = applicationId };
+                    db.Applications.Remove(application);
+                    await db.SaveChangesAsync();
+                }
+                else
+                {
+                    _logger.LogError("Failed to delete application: {appId}", applicationId);
+                }
             }
         }
         catch (Exception e)

--- a/src/AdminConsole/Services/PasswordlessManagementClient.cs
+++ b/src/AdminConsole/Services/PasswordlessManagementClient.cs
@@ -35,7 +35,7 @@ public class PasswordlessManagementClient : IPasswordlessManagementClient
 
     public async Task<bool> DeleteApplicationAsync(string application)
     {
-        var res = await _client.DeleteAsync($"admin/apps/{application}/delete");
+        var res = await _client.DeleteAsync($"admin/apps/{application}");
         return res.IsSuccessStatusCode;
     }
 


### PR DESCRIPTION
Currently, `ApplicationDeletionBackgroundService` was calling the wrong endpoint to delete the application in API. I fixed the url and also added a check in to provide additional logging when an application deletion failed during the API call.