### PR TITLE
Fixing Comment on Verify.cshtml

### DIFF
--- a/src/AdminConsole/Pages/Organization/Verify.cshtml
+++ b/src/AdminConsole/Pages/Organization/Verify.cshtml
@@ -7,7 +7,7 @@
 }
 
 @section Head {
-    // This to refresh the page to check if the user has verified and logged in
+    @* This to refresh the page to check if the user has verified and logged in *@
     <meta http-equiv="refresh" content="15" />
 }
 


### PR DESCRIPTION
Making the comment on `Verify.cshtml` a razor block comment. `//` inside of the `@section {}` block will only not show the `//`. The rest of the comment will still show. `@* *@` will work as a comment on a razor page.
