### PR TITLE
Event Logging Fixes

### DIFF
--- a/src/Api/Endpoints/Events.cs
+++ b/src/Api/Endpoints/Events.cs
@@ -33,16 +33,13 @@ public static class EventLog
 
         var tenantId = request.GetTenantName();
 
-        var eventsTask = storage.GetEventLogAsync(getEventLogEventsRequest.PageNumber, getEventLogEventsRequest.NumberOfResults ?? 100, cancellationToken);
-        var eventCountTasks = storage.GetEventLogCountAsync(cancellationToken);
-
-        await Task.WhenAll(eventsTask, eventCountTasks);
+        var events = await storage.GetEventLogAsync(getEventLogEventsRequest.PageNumber, getEventLogEventsRequest.NumberOfResults ?? 100, cancellationToken);
 
         return Results.Ok(new
         {
             TenantId = tenantId,
-            Events = eventsTask.Result.Select(x => x.ToEvent()),
-            TotalEventCount = eventCountTasks.Result
+            Events = events.Select(x => x.ToEvent()),
+            TotalEventCount = await storage.GetEventLogCountAsync(cancellationToken)
         });
     }
 

--- a/src/Service/EventLog/EventFunctions.cs
+++ b/src/Service/EventLog/EventFunctions.cs
@@ -129,19 +129,6 @@ public static class EventFunctions
             ApiKeyId = context.AbbreviatedKey
         });
 
-    public static void LogUserSignInBeganEvent(this IEventLogger logger, string? performedBy) =>
-        logger.LogEvent(context => new EventDto
-        {
-            PerformedAt = context.PerformedAt,
-            Message = string.IsNullOrWhiteSpace(performedBy) ? "Discoverable/Autofill sign in began." : $"User {performedBy} began sign in.",
-            PerformedBy = performedBy ?? "User",
-            EventType = EventType.ApiUserSignInBegan,
-            Severity = Severity.Informational,
-            Subject = context.TenantId,
-            TenantId = context.TenantId,
-            ApiKeyId = context.AbbreviatedKey
-        });
-
     public static void LogUserSignInCompletedEvent(this IEventLogger logger, string performedBy) =>
         logger.LogEvent(context => new EventDto
         {

--- a/src/Service/EventLog/EventFunctions.cs
+++ b/src/Service/EventLog/EventFunctions.cs
@@ -1,5 +1,6 @@
 using Passwordless.Common.EventLog.Enums;
 using Passwordless.Common.Models;
+using Passwordless.Service.EventLog.Loggers;
 using Passwordless.Service.EventLog.Models;
 
 namespace Passwordless.Service.EventLog;
@@ -115,9 +116,8 @@ public static class EventFunctions
         ApiKeyId = string.Empty
     };
 
-
-    public static Func<IEventLogContext, EventDto> DeleteCredentialEvent(string userId) =>
-        context => new EventDto
+    public static void LogDeleteCredentialEvent(this IEventLogger logger, string userId) =>
+        logger.LogEvent(context => new EventDto
         {
             PerformedAt = context.PerformedAt,
             Message = $"Deleted credential for user {userId}",
@@ -127,43 +127,46 @@ public static class EventFunctions
             Severity = Severity.Informational,
             Subject = userId,
             ApiKeyId = context.AbbreviatedKey
-        };
+        });
 
-    public static EventDto UserSignInBeganEvent(string performedBy, IEventLogContext eventLogContext) => new()
-    {
-        PerformedAt = eventLogContext.PerformedAt,
-        Message = $"User {performedBy} began sign in.",
-        PerformedBy = performedBy,
-        EventType = EventType.ApiUserSignInBegan,
-        Severity = Severity.Informational,
-        Subject = eventLogContext.TenantId,
-        TenantId = eventLogContext.TenantId,
-        ApiKeyId = eventLogContext.AbbreviatedKey
-    };
+    public static void LogUserSignInBeganEvent(this IEventLogger logger, string? performedBy) =>
+        logger.LogEvent(context => new EventDto
+        {
+            PerformedAt = context.PerformedAt,
+            Message = string.IsNullOrWhiteSpace(performedBy) ? "Discoverable/Autofill sign in began." : $"User {performedBy} began sign in.",
+            PerformedBy = performedBy ?? "User",
+            EventType = EventType.ApiUserSignInBegan,
+            Severity = Severity.Informational,
+            Subject = context.TenantId,
+            TenantId = context.TenantId,
+            ApiKeyId = context.AbbreviatedKey
+        });
 
-    public static EventDto UserSignInCompletedEvent(string performedBy, IEventLogContext eventLogContext) => new()
-    {
-        PerformedAt = eventLogContext.PerformedAt,
-        Message = $"User {performedBy} completed sign in.",
-        PerformedBy = performedBy,
-        TenantId = eventLogContext.TenantId,
-        EventType = EventType.ApiUserSignInCompleted,
-        Severity = Severity.Informational,
-        Subject = eventLogContext.TenantId,
-        ApiKeyId = eventLogContext.AbbreviatedKey
-    };
+    public static void LogUserSignInCompletedEvent(this IEventLogger logger, string performedBy) =>
+        logger.LogEvent(context => new EventDto
+        {
+            PerformedAt = context.PerformedAt,
+            Message = $"User {performedBy} completed sign in.",
+            PerformedBy = performedBy,
+            TenantId = context.TenantId,
+            EventType = EventType.ApiUserSignInCompleted,
+            Severity = Severity.Informational,
+            Subject = context.TenantId,
+            ApiKeyId = context.AbbreviatedKey
+        });
 
-    public static EventDto UserSignInTokenVerifiedEvent(string performedBy, IEventLogContext eventLogContext) => new()
-    {
-        PerformedAt = eventLogContext.PerformedAt,
-        Message = $"User {performedBy} verified sign in token.",
-        PerformedBy = performedBy,
-        TenantId = eventLogContext.TenantId,
-        EventType = EventType.ApiUserSignInVerified,
-        Severity = Severity.Informational,
-        Subject = eventLogContext.TenantId,
-        ApiKeyId = eventLogContext.AbbreviatedKey
-    };
+    public static void LogUserSignInTokenVerifiedEvent(this IEventLogger logger, string performedBy) =>
+        logger.LogEvent(context => new EventDto
+        {
+            PerformedAt = context.PerformedAt,
+            Message = $"User {performedBy} verified sign in token.",
+            PerformedBy = performedBy,
+            TenantId = context.TenantId,
+            EventType = EventType.ApiUserSignInVerified,
+            Severity = Severity.Informational,
+            Subject = context.TenantId,
+            ApiKeyId = context.AbbreviatedKey
+        });
 
     public static Func<IEventLogContext, EventDto> DeletedUserEvent(string userId) =>
         context => new EventDto

--- a/src/Service/Fido2ServiceEndpoints.cs
+++ b/src/Service/Fido2ServiceEndpoints.cs
@@ -134,7 +134,7 @@ public class Fido2ServiceEndpoints : IFido2Service
     {
         var token = _tokenService.DecodeToken<VerifySignInToken>(payload.Token, "verify_");
 
-        _eventLogger.LogEvent(UserSignInTokenVerifiedEvent(token.UserId, _eventLogContext));
+        _eventLogger.LogUserSignInTokenVerifiedEvent(token.UserId);
 
         return Task.FromResult(token);
     }
@@ -295,7 +295,7 @@ public class Fido2ServiceEndpoints : IFido2Service
             uv
         );
 
-        _eventLogger.LogEvent(UserSignInBeganEvent(request.UserId, _eventLogContext));
+        _eventLogger.LogUserSignInBeganEvent(request.UserId ?? request.Alias);
 
         var session = _tokenService.EncodeToken(options, "session_", true);
 
@@ -352,7 +352,7 @@ public class Fido2ServiceEndpoints : IFido2Service
             Type = "passkey_signin"
         };
 
-        _eventLogger.LogEvent(UserSignInCompletedEvent(userId, _eventLogContext));
+        _eventLogger.LogUserSignInCompletedEvent(userId);
 
         var token = _tokenService.EncodeToken(tokenData, "verify_");
 

--- a/src/Service/Fido2ServiceEndpoints.cs
+++ b/src/Service/Fido2ServiceEndpoints.cs
@@ -295,8 +295,6 @@ public class Fido2ServiceEndpoints : IFido2Service
             uv
         );
 
-        _eventLogger.LogUserSignInBeganEvent(request.UserId ?? request.Alias);
-
         var session = _tokenService.EncodeToken(options, "session_", true);
 
         // Return options to client

--- a/src/Service/UserCredentialsService.cs
+++ b/src/Service/UserCredentialsService.cs
@@ -1,8 +1,8 @@
-﻿using Passwordless.Service.EventLog.Loggers;
+﻿using Passwordless.Service.EventLog;
+using Passwordless.Service.EventLog.Loggers;
 using Passwordless.Service.Helpers;
 using Passwordless.Service.Models;
 using Passwordless.Service.Storage.Ef;
-using static Passwordless.Service.EventLog.EventFunctions;
 
 namespace Passwordless.Service;
 
@@ -41,7 +41,7 @@ public class UserCredentialsService
 
         await _storage.DeleteCredential(credentialId);
 
-        _eventLogger.LogEvent(DeleteCredentialEvent(credential.UserId));
+        _eventLogger.LogDeleteCredentialEvent(credential.UserId);
     }
 
     public Task<List<UserSummary>> GetAllUsers(string paginationLastId)


### PR DESCRIPTION
Two issues being fixed here. `signInWithAlias`, `signInWithAutoFill`, and `signInWithDiscoverable` all sent UserId as null which was unexpected.  Added some null checking and better wording for sign in event.

There was also the same concurrency issue from EF when using the same context for multiple concurrent calls.