### PR TITLE
Dates Show as "Invalid Date"

### DIFF
--- a/src/AdminConsole/Pages/App/Credentials/List.cshtml
+++ b/src/AdminConsole/Pages/App/Credentials/List.cshtml
@@ -32,7 +32,7 @@
                 <td class="whitespace-nowrap">
                     @if (user.LastUsedAt.HasValue)
                     {
-                        <local-time datetime="@user.LastUsedAt.Value.ToString("O")"></local-time>
+                        <local-time datetime="@user.LastUsedAt.Value"></local-time>
                     }
                 </td>
             </tr>

--- a/src/AdminConsole/Pages/App/Credentials/List.cshtml
+++ b/src/AdminConsole/Pages/App/Credentials/List.cshtml
@@ -32,7 +32,7 @@
                 <td class="whitespace-nowrap">
                     @if (user.LastUsedAt.HasValue)
                     {
-                        <local-time datetime="@user.LastUsedAt.Value"></local-time>
+                        <local-time datetime="@user.LastUsedAt.Value.ToString("O")"></local-time>
                     }
                 </td>
             </tr>

--- a/src/AdminConsole/Pages/App/Credentials/List.cshtml
+++ b/src/AdminConsole/Pages/App/Credentials/List.cshtml
@@ -32,7 +32,7 @@
                 <td class="whitespace-nowrap">
                     @if (user.LastUsedAt.HasValue)
                     {
-                        <local-time datetime="@user.LastUsedAt.Value"></local-time>
+                        <asp-local-time datetime="@user.LastUsedAt.Value" />
                     }
                 </td>
             </tr>

--- a/src/AdminConsole/Pages/App/Credentials/User.cshtml
+++ b/src/AdminConsole/Pages/App/Credentials/User.cshtml
@@ -44,11 +44,11 @@
           <dl class="mt-2">
             <div class="flex items-center">
               <dt class="text-sm font-medium text-gray-500 mr-2">Created:</dt>
-              <dd class="text-sm text-gray-900"><local-time datetime="@cred.CreatedAt.ToString("O")"></local-time></dd>
+              <dd class="text-sm text-gray-900"><local-time datetime="@cred.CreatedAt"></local-time></dd>
             </div>
             <div class="flex items-center">
               <dt class="text-sm font-medium text-gray-500 mr-2">Last used:</dt>
-              <dd class="text-sm text-gray-900"><local-time datetime="@cred.LastUsedAt.ToString("O")"></local-time></dd>
+              <dd class="text-sm text-gray-900"><local-time datetime="@cred.LastUsedAt"></local-time></dd>
             </div>
             <button
               type="button"

--- a/src/AdminConsole/Pages/App/Credentials/User.cshtml
+++ b/src/AdminConsole/Pages/App/Credentials/User.cshtml
@@ -44,11 +44,11 @@
           <dl class="mt-2">
             <div class="flex items-center">
               <dt class="text-sm font-medium text-gray-500 mr-2">Created:</dt>
-              <dd class="text-sm text-gray-900"><local-time datetime="@cred.CreatedAt"></local-time></dd>
+                <dd class="text-sm text-gray-900"><asp-local-time datetime="@cred.CreatedAt" /></dd>
             </div>
             <div class="flex items-center">
               <dt class="text-sm font-medium text-gray-500 mr-2">Last used:</dt>
-              <dd class="text-sm text-gray-900"><local-time datetime="@cred.LastUsedAt"></local-time></dd>
+                <dd class="text-sm text-gray-900"><asp-local-time datetime="@cred.LastUsedAt" /></dd>
             </div>
             <button
               type="button"

--- a/src/AdminConsole/Pages/App/Credentials/User.cshtml
+++ b/src/AdminConsole/Pages/App/Credentials/User.cshtml
@@ -44,11 +44,11 @@
           <dl class="mt-2">
             <div class="flex items-center">
               <dt class="text-sm font-medium text-gray-500 mr-2">Created:</dt>
-              <dd class="text-sm text-gray-900"><local-time datetime="@cred.CreatedAt"></local-time></dd>
+              <dd class="text-sm text-gray-900"><local-time datetime="@cred.CreatedAt.ToString("O")"></local-time></dd>
             </div>
             <div class="flex items-center">
               <dt class="text-sm font-medium text-gray-500 mr-2">Last used:</dt>
-              <dd class="text-sm text-gray-900"><local-time datetime="@cred.LastUsedAt"></local-time></dd>
+              <dd class="text-sm text-gray-900"><local-time datetime="@cred.LastUsedAt.ToString("O")"></local-time></dd>
             </div>
             <button
               type="button"

--- a/src/AdminConsole/Pages/App/Logs/Log.cshtml
+++ b/src/AdminConsole/Pages/App/Logs/Log.cshtml
@@ -43,7 +43,7 @@
                         {
                             <tr>
                                 <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6">
-                                    <local-time datetime="@logEvent.PerformedAt" />
+                                    <asp-local-time datetime="@logEvent.PerformedAt" />
                                 </td>
                                 <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
                                     @logEvent.PerformedBy

--- a/src/AdminConsole/Pages/App/Logs/Log.cshtml
+++ b/src/AdminConsole/Pages/App/Logs/Log.cshtml
@@ -42,9 +42,8 @@
                         @foreach (var logEvent in Model.Events)
                         {
                             <tr>
-                                <td
-                                    class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6">
-                                    @logEvent.PerformedAt
+                                <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6">
+                                    <local-time datetime="@logEvent.PerformedAt.ToString("O")" />
                                 </td>
                                 <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
                                     @logEvent.PerformedBy

--- a/src/AdminConsole/Pages/App/Logs/Log.cshtml
+++ b/src/AdminConsole/Pages/App/Logs/Log.cshtml
@@ -43,7 +43,7 @@
                         {
                             <tr>
                                 <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6">
-                                    <local-time datetime="@logEvent.PerformedAt.ToString("O")" />
+                                    <local-time datetime="@logEvent.PerformedAt" />
                                 </td>
                                 <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
                                     @logEvent.PerformedBy

--- a/src/AdminConsole/Pages/Components/ManagePasskeys/Default.cshtml
+++ b/src/AdminConsole/Pages/Components/ManagePasskeys/Default.cshtml
@@ -17,11 +17,11 @@
                             <dl class="mt-2">
                                 <div class="flex items-center">
                                     <dt class="text-sm font-medium text-gray-500 mr-2">Created:</dt>
-                                    <dd class="text-sm text-gray-900"><local-time datetime="@cred.CreatedAt"></local-time></dd>
+                                    <dd class="text-sm text-gray-900"><asp-local-time datetime="@cred.CreatedAt" /></dd>
                                 </div>
                                 <div class="flex items-center">
                                     <dt class="text-sm font-medium text-gray-500 mr-2">Last used:</dt>
-                                    <dd class="text-sm text-gray-900"><local-time datetime="@cred.LastUsedAt"></local-time></dd>
+                                    <dd class="text-sm text-gray-900"><asp-local-time datetime="@cred.LastUsedAt" /></dd>
                                 </div>
 
                                 <button

--- a/src/AdminConsole/Pages/Components/ManagePasskeys/Default.cshtml
+++ b/src/AdminConsole/Pages/Components/ManagePasskeys/Default.cshtml
@@ -17,11 +17,11 @@
                             <dl class="mt-2">
                                 <div class="flex items-center">
                                     <dt class="text-sm font-medium text-gray-500 mr-2">Created:</dt>
-                                    <dd class="text-sm text-gray-900"><local-time datetime="@cred.CreatedAt.ToString("O")"></local-time></dd>
+                                    <dd class="text-sm text-gray-900"><local-time datetime="@cred.CreatedAt"></local-time></dd>
                                 </div>
                                 <div class="flex items-center">
                                     <dt class="text-sm font-medium text-gray-500 mr-2">Last used:</dt>
-                                    <dd class="text-sm text-gray-900"><local-time datetime="@cred.LastUsedAt.ToString("O")"></local-time></dd>
+                                    <dd class="text-sm text-gray-900"><local-time datetime="@cred.LastUsedAt"></local-time></dd>
                                 </div>
 
                                 <button

--- a/src/AdminConsole/Pages/Components/ManagePasskeys/Default.cshtml
+++ b/src/AdminConsole/Pages/Components/ManagePasskeys/Default.cshtml
@@ -17,11 +17,11 @@
                             <dl class="mt-2">
                                 <div class="flex items-center">
                                     <dt class="text-sm font-medium text-gray-500 mr-2">Created:</dt>
-                                    <dd class="text-sm text-gray-900"><local-time datetime="@cred.CreatedAt"></local-time></dd>
+                                    <dd class="text-sm text-gray-900"><local-time datetime="@cred.CreatedAt.ToString("O")"></local-time></dd>
                                 </div>
                                 <div class="flex items-center">
                                     <dt class="text-sm font-medium text-gray-500 mr-2">Last used:</dt>
-                                    <dd class="text-sm text-gray-900"><local-time datetime="@cred.LastUsedAt"></local-time></dd>
+                                    <dd class="text-sm text-gray-900"><local-time datetime="@cred.LastUsedAt.ToString("O")"></local-time></dd>
                                 </div>
 
                                 <button

--- a/src/AdminConsole/Pages/Organization/Admins.cshtml
+++ b/src/AdminConsole/Pages/Organization/Admins.cshtml
@@ -82,7 +82,7 @@
                     {
                         <tr>
                             <td class="whitespace-nowrap">@inv.ToEmail</td>
-                            <td class="whitespace-nowrap"><local-time datetime="@inv.CreatedAt"></local-time></td>
+                            <td class="whitespace-nowrap"><asp-local-time datetime="@inv.CreatedAt" /></td>
                             <td class="whitespace-nowrap">Sent</td>
                             <td class="whitespace-nowrap">@inv.FromName</td>
                             <td class="whitespace-nowrap">

--- a/src/AdminConsole/Pages/Organization/Admins.cshtml
+++ b/src/AdminConsole/Pages/Organization/Admins.cshtml
@@ -82,7 +82,7 @@
                     {
                         <tr>
                             <td class="whitespace-nowrap">@inv.ToEmail</td>
-                            <td class="whitespace-nowrap"><local-time datetime="@inv.CreatedAt"></local-time></td>
+                            <td class="whitespace-nowrap"><local-time datetime="@inv.CreatedAt.ToString("O")"></local-time></td>
                             <td class="whitespace-nowrap">Sent</td>
                             <td class="whitespace-nowrap">@inv.FromName</td>
                             <td class="whitespace-nowrap">

--- a/src/AdminConsole/Pages/Organization/Admins.cshtml
+++ b/src/AdminConsole/Pages/Organization/Admins.cshtml
@@ -82,7 +82,7 @@
                     {
                         <tr>
                             <td class="whitespace-nowrap">@inv.ToEmail</td>
-                            <td class="whitespace-nowrap"><local-time datetime="@inv.CreatedAt.ToString("O")"></local-time></td>
+                            <td class="whitespace-nowrap"><local-time datetime="@inv.CreatedAt"></local-time></td>
                             <td class="whitespace-nowrap">Sent</td>
                             <td class="whitespace-nowrap">@inv.FromName</td>
                             <td class="whitespace-nowrap">

--- a/src/AdminConsole/Pages/Organization/Log.cshtml
+++ b/src/AdminConsole/Pages/Organization/Log.cshtml
@@ -40,7 +40,7 @@
                         {
                             <tr>
                                 <td class="whitespace-nowrap td-indent td-strong">
-                                    <local-time datetime="@logEvent.PerformedAt" />
+                                    <asp-local-time datetime="@logEvent.PerformedAt" />
                                 </td>
                                 <td class="whitespace-nowrap">
                                     @logEvent.PerformedBy

--- a/src/AdminConsole/Pages/Organization/Log.cshtml
+++ b/src/AdminConsole/Pages/Organization/Log.cshtml
@@ -40,7 +40,7 @@
                         {
                             <tr>
                                 <td class="whitespace-nowrap td-indent td-strong">
-                                    <local-time datetime="@logEvent.PerformedAt.ToString("O")" />
+                                    <local-time datetime="@logEvent.PerformedAt" />
                                 </td>
                                 <td class="whitespace-nowrap">
                                     @logEvent.PerformedBy

--- a/src/AdminConsole/Pages/Organization/Log.cshtml
+++ b/src/AdminConsole/Pages/Organization/Log.cshtml
@@ -39,9 +39,8 @@
                         @foreach (var logEvent in Model.Events)
                         {
                             <tr>
-                                <td
-                                    class="whitespace-nowrap td-indent td-strong">
-                                    @logEvent.PerformedAt
+                                <td class="whitespace-nowrap td-indent td-strong">
+                                    <local-time datetime="@logEvent.PerformedAt.ToString("O")" />
                                 </td>
                                 <td class="whitespace-nowrap">
                                     @logEvent.PerformedBy

--- a/src/AdminConsole/Pages/Organization/Overview.cshtml
+++ b/src/AdminConsole/Pages/Organization/Overview.cshtml
@@ -25,7 +25,7 @@
                     <div class="hidden md:block">
                         <div>
                             <p class="text-sm text-gray-900">
-                                Created: <local-time datetime="@app.CreatedAt"></local-time>
+                                Created: <asp-local-time datetime="@app.CreatedAt" />
                             </p>
                             <p class="mt-2 flex items-center text-sm text-gray-500">
                                 @*  <svg class="mr-1.5 h-5 w-5 flex-shrink-0" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6"> *@
@@ -36,7 +36,7 @@
                             @if (app.DeleteAt.HasValue)
                             {
                                 <p class="mt-2 text-sm text-red-900">
-                                    Being deleted at: <local-time datetime="@app.DeleteAt.Value"></local-time>
+                                    Being deleted at: <asp-local-time datetime="@app.DeleteAt.Value" />
                                 </p>
                             }
                         </div>

--- a/src/AdminConsole/Pages/Organization/Overview.cshtml
+++ b/src/AdminConsole/Pages/Organization/Overview.cshtml
@@ -25,7 +25,7 @@
                     <div class="hidden md:block">
                         <div>
                             <p class="text-sm text-gray-900">
-                                Created: <local-time datetime="@app.CreatedAt"></local-time>
+                                Created: <local-time datetime="@app.CreatedAt.ToString("O")"></local-time>
                             </p>
                             <p class="mt-2 flex items-center text-sm text-gray-500">
                                 @*  <svg class="mr-1.5 h-5 w-5 flex-shrink-0" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6"> *@
@@ -36,7 +36,7 @@
                             @if (app.DeleteAt.HasValue)
                             {
                                 <p class="mt-2 text-sm text-red-900">
-                                    Being deleted at: <local-time datetime="@app.DeleteAt.Value"></local-time>
+                                    Being deleted at: <local-time datetime="@app.DeleteAt.Value.ToString("O")"></local-time>
                                 </p>
                             }
                         </div>

--- a/src/AdminConsole/Pages/Organization/Overview.cshtml
+++ b/src/AdminConsole/Pages/Organization/Overview.cshtml
@@ -25,7 +25,7 @@
                     <div class="hidden md:block">
                         <div>
                             <p class="text-sm text-gray-900">
-                                Created: <local-time datetime="@app.CreatedAt.ToString("O")"></local-time>
+                                Created: <local-time datetime="@app.CreatedAt"></local-time>
                             </p>
                             <p class="mt-2 flex items-center text-sm text-gray-500">
                                 @*  <svg class="mr-1.5 h-5 w-5 flex-shrink-0" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6"> *@
@@ -36,7 +36,7 @@
                             @if (app.DeleteAt.HasValue)
                             {
                                 <p class="mt-2 text-sm text-red-900">
-                                    Being deleted at: <local-time datetime="@app.DeleteAt.Value.ToString("O")"></local-time>
+                                    Being deleted at: <local-time datetime="@app.DeleteAt.Value"></local-time>
                                 </p>
                             }
                         </div>

--- a/src/AdminConsole/Pages/Shared/_Credentials.cshtml
+++ b/src/AdminConsole/Pages/Shared/_Credentials.cshtml
@@ -15,13 +15,13 @@
                                 <div class="flex items-center">
                                     <dt class="text-sm font-medium text-gray-500 mr-2">Created:</dt>
                                     <dd class="text-sm text-gray-900">
-                                        <local-time datetime="@cred.CreatedAt"></local-time>
+                                        <local-time datetime="@cred.CreatedAt.ToString("O")"></local-time>
                                     </dd>
                                 </div>
                                 <div class="flex items-center">
                                     <dt class="text-sm font-medium text-gray-500 mr-2">Last used:</dt>
                                     <dd class="text-sm text-gray-900">
-                                        <local-time datetime="@cred.LastUsedAt"></local-time>
+                                        <local-time datetime="@cred.LastUsedAt.ToString("O")"></local-time>
                                     </dd>
                                 </div>
 

--- a/src/AdminConsole/Pages/Shared/_Credentials.cshtml
+++ b/src/AdminConsole/Pages/Shared/_Credentials.cshtml
@@ -15,13 +15,13 @@
                                 <div class="flex items-center">
                                     <dt class="text-sm font-medium text-gray-500 mr-2">Created:</dt>
                                     <dd class="text-sm text-gray-900">
-                                        <local-time datetime="@cred.CreatedAt.ToString("O")"></local-time>
+                                        <local-time datetime="@cred.CreatedAt"></local-time>
                                     </dd>
                                 </div>
                                 <div class="flex items-center">
                                     <dt class="text-sm font-medium text-gray-500 mr-2">Last used:</dt>
                                     <dd class="text-sm text-gray-900">
-                                        <local-time datetime="@cred.LastUsedAt.ToString("O")"></local-time>
+                                        <local-time datetime="@cred.LastUsedAt"></local-time>
                                     </dd>
                                 </div>
 

--- a/src/AdminConsole/Pages/Shared/_Credentials.cshtml
+++ b/src/AdminConsole/Pages/Shared/_Credentials.cshtml
@@ -15,13 +15,13 @@
                                 <div class="flex items-center">
                                     <dt class="text-sm font-medium text-gray-500 mr-2">Created:</dt>
                                     <dd class="text-sm text-gray-900">
-                                        <local-time datetime="@cred.CreatedAt"></local-time>
+                                        <asp-local-time datetime="@cred.CreatedAt" />
                                     </dd>
                                 </div>
                                 <div class="flex items-center">
                                     <dt class="text-sm font-medium text-gray-500 mr-2">Last used:</dt>
                                     <dd class="text-sm text-gray-900">
-                                        <local-time datetime="@cred.LastUsedAt"></local-time>
+                                        <asp-local-time datetime="@cred.LastUsedAt" />
                                     </dd>
                                 </div>
 

--- a/src/AdminConsole/TagHelpers/LocalTime.cs
+++ b/src/AdminConsole/TagHelpers/LocalTime.cs
@@ -1,0 +1,15 @@
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace Passwordless.AdminConsole.TagHelpers;
+
+[HtmlTargetElement("local-time")]
+public class LocalTime : TagHelper
+{
+    [HtmlAttributeName("datetime")]
+    public DateTime DateTime { get; set; }
+
+    public override void Process(TagHelperContext context, TagHelperOutput output)
+    {
+        output.Attributes.Add("datetime", DateTime.ToString("O"));
+    }
+}

--- a/src/AdminConsole/TagHelpers/LocalTime.cs
+++ b/src/AdminConsole/TagHelpers/LocalTime.cs
@@ -10,6 +10,6 @@ public class LocalTime : TagHelper
 
     public override void Process(TagHelperContext context, TagHelperOutput output)
     {
-        output.Attributes.Add("datetime", DateTime.ToString("O"));
+        output.Attributes.Add("datetime", DateTime.SpecifyKind(DateTime, DateTimeKind.Utc).ToString("O"));
     }
 }

--- a/src/AdminConsole/TagHelpers/LocalTime.cs
+++ b/src/AdminConsole/TagHelpers/LocalTime.cs
@@ -2,7 +2,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace Passwordless.AdminConsole.TagHelpers;
 
-[HtmlTargetElement("local-time")]
+[HtmlTargetElement("asp-local-time")]
 public class LocalTime : TagHelper
 {
     [HtmlAttributeName("datetime")]
@@ -10,6 +10,7 @@ public class LocalTime : TagHelper
 
     public override void Process(TagHelperContext context, TagHelperOutput output)
     {
+        output.TagName = "local-time";
         output.Attributes.Add("datetime", DateTime.SpecifyKind(DateTime, DateTimeKind.Utc).ToString("O"));
     }
 }


### PR DESCRIPTION
When removing `.ToLocalTime()` from razor pages, some mac browsers stopped being able to process the datetime string when calling `new Date()`.  Added `.ToString("O")` so it would format to ISO-8601 standard.

Also added `<local-time />` component to Log pages.