### PR TITLE
Add Event for successful admin sign-in

### DIFF
--- a/src/AdminConsole/EventLog/Loggers/IEventLogger.cs
+++ b/src/AdminConsole/EventLog/Loggers/IEventLogger.cs
@@ -1,4 +1,6 @@
+using System.Security.Claims;
 using Passwordless.AdminConsole.EventLog.DTOs;
+using Passwordless.AdminConsole.Helpers;
 using Passwordless.AdminConsole.Identity;
 using Passwordless.AdminConsole.Models;
 using Passwordless.Common.EventLog.Enums;
@@ -115,6 +117,21 @@ public static class EventLoggerExtensions
                 Severity.Informational,
                 consoleAdmin.OrganizationId.ToString(),
                 consoleAdmin.OrganizationId,
+                performedAt
+            )
+        );
+
+    public static void LogAdminLoginTokenVerifiedEvent(
+        this IEventLogger logger,
+        ClaimsPrincipal claimsPrincipal,
+        DateTime performedAt) =>
+        logger.LogEvent(
+            new(claimsPrincipal.GetId(),
+                EventType.AdminSignInTokenVerified,
+                $"{claimsPrincipal.GetName()} successfully signed-in via passkey.",
+                Severity.Informational,
+                claimsPrincipal.GetOrgId()?.ToString() ?? string.Empty,
+                claimsPrincipal.GetOrgId().GetValueOrDefault(),
                 performedAt
             )
         );

--- a/src/AdminConsole/Helpers/ClaimsExtension.cs
+++ b/src/AdminConsole/Helpers/ClaimsExtension.cs
@@ -17,4 +17,10 @@ public static class ClaimsExtension
     {
         return user.FindFirstValue(ClaimTypes.Email);
     }
+
+    public static string GetId(this ClaimsPrincipal user) =>
+        user.FindFirstValue(ClaimTypes.NameIdentifier) ?? string.Empty;
+
+    public static string GetName(this ClaimsPrincipal user) =>
+        user.FindFirstValue(ClaimTypes.Name) ?? string.Empty;
 }

--- a/src/AdminConsole/Helpers/LoginEndpointFilter.cs
+++ b/src/AdminConsole/Helpers/LoginEndpointFilter.cs
@@ -1,0 +1,29 @@
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Passwordless.AdminConsole.EventLog.Loggers;
+
+namespace Passwordless.AdminConsole.Helpers;
+
+public class LoginEndpointFilter : IEndpointFilter
+{
+    private readonly IEventLogger _logger;
+    private readonly ISystemClock _systemClock;
+
+    public LoginEndpointFilter(IEventLogger logger, ISystemClock systemClock)
+    {
+        _logger = logger;
+        _systemClock = systemClock;
+    }
+
+    public async ValueTask<object?> InvokeAsync(EndpointFilterInvocationContext context, EndpointFilterDelegate next)
+    {
+        var result = await next(context);
+
+        if (result is SignInHttpResult { Principal.Identity.IsAuthenticated: true } signInHttpResult)
+        {
+            _logger.LogAdminLoginTokenVerifiedEvent(signInHttpResult.Principal, _systemClock.UtcNow.UtcDateTime);
+        }
+
+        return result;
+    }
+}

--- a/src/AdminConsole/Program.cs
+++ b/src/AdminConsole/Program.cs
@@ -188,7 +188,8 @@ void RunTheApp()
     app.UseMiddleware<CurrentContextMiddleware>();
     app.UseMiddleware<EventLogStorageCommitMiddleware>();
     app.UseAuthorization();
-    app.MapPasswordless();
+    app.MapPasswordless()
+        .LoginRoute?.AddEndpointFilter<LoginEndpointFilter>();
     app.MapRazorPages();
     app.Run();
 }

--- a/src/Common/EventLog/Enums/EventType.cs
+++ b/src/Common/EventLog/Enums/EventType.cs
@@ -23,5 +23,6 @@ public enum EventType
     AdminDeleteAdmin = 7003,
     AdminCancelAdminInvite = 7004,
     AdminInvalidInviteUsed = 7005,
-    AdminAcceptedInvite = 7006
+    AdminAcceptedInvite = 7006,
+    AdminSignInTokenVerified = 7007
 }


### PR DESCRIPTION
This adds an event to the organization event log for a successful admin sign-in from passkey.  I used and endpoint filter off the `.MapPasswordless()` endpoint builder because we use the `Passwordless` nuget package for sign in to the admin console.  This way we can allow everything to be default out of the box.  If there's a better way to do this, let me know.