### PR TITLE
Delete event logs outside of the retention period.

### DIFF
--- a/src/AdminConsole/EventLog/AddEventLoggingRegistration.cs
+++ b/src/AdminConsole/EventLog/AddEventLoggingRegistration.cs
@@ -13,7 +13,9 @@ public static class AddEventLoggingRegistration
             .AddScoped<EventLoggerEfWriteStorage<TDbContext>>()
             .AddScoped<EventLoggerEfUnauthenticatedWriteStorage<TDbContext>>()
             .AddScoped(GetEventLogger<TDbContext>)
-            .AddTransient<IEventLogService, EventLogService>();
+            .AddTransient<IInternalEventStorage, InternalEventStorage<TDbContext>>()
+            .AddTransient<IEventLogService, EventLogService>()
+            .AddHostedService<EventDeletionBackgroundWorker>();
 
     private static IEventLogger GetEventLogger<TDbContext>(IServiceProvider serviceProvider) where TDbContext : ConsoleDbContext =>
         serviceProvider.GetRequiredService<ICurrentContext>() switch

--- a/src/AdminConsole/EventLog/AddEventLoggingRegistration.cs
+++ b/src/AdminConsole/EventLog/AddEventLoggingRegistration.cs
@@ -13,7 +13,7 @@ public static class AddEventLoggingRegistration
             .AddScoped<EventLoggerEfWriteStorage<TDbContext>>()
             .AddScoped<EventLoggerEfUnauthenticatedWriteStorage<TDbContext>>()
             .AddScoped(GetEventLogger<TDbContext>)
-            .AddTransient<IInternalEventStorage, InternalEventStorage<TDbContext>>()
+            .AddTransient<IInternalEventLogStorageContext, InternalEventLogStorageContext<TDbContext>>()
             .AddTransient<IEventLogService, EventLogService>()
             .AddHostedService<EventDeletionBackgroundWorker>();
 

--- a/src/AdminConsole/EventLog/EventDeletionBackgroundWorker.cs
+++ b/src/AdminConsole/EventLog/EventDeletionBackgroundWorker.cs
@@ -5,14 +5,14 @@ namespace Passwordless.AdminConsole.EventLog;
 public class EventDeletionBackgroundWorker : BackgroundService
 {
     private readonly ILogger<EventDeletionBackgroundWorker> _logger;
-    private readonly IInternalEventStorage _internalEventStorage;
+    private readonly IInternalEventLogStorageContext _internalEventLogStorageContext;
 
     public EventDeletionBackgroundWorker(
         ILogger<EventDeletionBackgroundWorker> logger,
-        IInternalEventStorage internalEventStorage)
+        IInternalEventLogStorageContext internalEventLogStorageContext)
     {
         _logger = logger;
-        _internalEventStorage = internalEventStorage;
+        _internalEventLogStorageContext = internalEventLogStorageContext;
     }
 
     protected async override Task ExecuteAsync(CancellationToken stoppingToken)
@@ -25,7 +25,7 @@ public class EventDeletionBackgroundWorker : BackgroundService
         {
             do
             {
-                await _internalEventStorage.DeleteExpiredEvents(stoppingToken);
+                await _internalEventLogStorageContext.DeleteExpiredEvents(stoppingToken);
             } while (await timer.WaitForNextTickAsync(stoppingToken));
         }
         catch (OperationCanceledException)

--- a/src/AdminConsole/EventLog/EventDeletionBackgroundWorker.cs
+++ b/src/AdminConsole/EventLog/EventDeletionBackgroundWorker.cs
@@ -1,0 +1,40 @@
+using Passwordless.AdminConsole.EventLog.Loggers;
+
+namespace Passwordless.AdminConsole.EventLog;
+
+public class EventDeletionBackgroundWorker : BackgroundService
+{
+    private readonly ILogger<EventDeletionBackgroundWorker> _logger;
+    private readonly IInternalEventStorage _internalEventStorage;
+
+    public EventDeletionBackgroundWorker(
+        ILogger<EventDeletionBackgroundWorker> logger,
+        IInternalEventStorage internalEventStorage)
+    {
+        _logger = logger;
+        _internalEventStorage = internalEventStorage;
+    }
+
+    protected async override Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("Starting Event Log Deletion Worker");
+
+        using PeriodicTimer timer = new(TimeSpan.FromDays(1));
+
+        try
+        {
+            do
+            {
+                await _internalEventStorage.DeleteExpiredEvents(stoppingToken);
+            } while (await timer.WaitForNextTickAsync(stoppingToken));
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogInformation("Event Log Deletion Worker was cancelled.");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Event Log Deletion failed.");
+        }
+    }
+}

--- a/src/AdminConsole/EventLog/Loggers/EventLoggerEfReadStorage.cs
+++ b/src/AdminConsole/EventLog/Loggers/EventLoggerEfReadStorage.cs
@@ -7,6 +7,7 @@ namespace Passwordless.AdminConsole.EventLog.Loggers;
 public class EventLoggerEfReadStorage<TDbContext> : IEventLoggerStorage where TDbContext : ConsoleDbContext
 {
     private readonly IDbContextFactory<TDbContext> _dbContextFactory;
+
     public EventLoggerEfReadStorage(IDbContextFactory<TDbContext> dbContextFactory)
     {
         _dbContextFactory = dbContextFactory;
@@ -25,8 +26,6 @@ public class EventLoggerEfReadStorage<TDbContext> : IEventLoggerStorage where TD
                 .ToListAsync())
             .Select(x => x.ToDto());
     }
-
-
 
     public async Task<int> GetOrganizationEventCount(int organizationId)
     {

--- a/src/AdminConsole/EventLog/Loggers/InternalEventStorage.cs
+++ b/src/AdminConsole/EventLog/Loggers/InternalEventStorage.cs
@@ -6,18 +6,18 @@ using Passwordless.AdminConsole.Db;
 
 namespace Passwordless.AdminConsole.EventLog.Loggers;
 
-public interface IInternalEventStorage
+public interface IInternalEventLogStorageContext
 {
     Task DeleteExpiredEvents(CancellationToken cancellationToken);
 }
 
-public class InternalEventStorage<TDbContext> : IInternalEventStorage where TDbContext : ConsoleDbContext
+public class InternalEventLogStorageContext<TDbContext> : IInternalEventLogStorageContext where TDbContext : ConsoleDbContext
 {
     private readonly IDbContextFactory<TDbContext> _dbContextFactory;
     private readonly IOptions<PlansOptions> _planOptionsConfig;
     private readonly ISystemClock _systemClock;
 
-    public InternalEventStorage(IDbContextFactory<TDbContext> dbContextFactory,
+    public InternalEventLogStorageContext(IDbContextFactory<TDbContext> dbContextFactory,
         IOptions<PlansOptions> planOptionsConfig,
         ISystemClock systemClock)
     {

--- a/src/AdminConsole/EventLog/Loggers/InternalEventStorage.cs
+++ b/src/AdminConsole/EventLog/Loggers/InternalEventStorage.cs
@@ -1,0 +1,44 @@
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using Passwordless.AdminConsole.Configuration;
+using Passwordless.AdminConsole.Db;
+
+namespace Passwordless.AdminConsole.EventLog.Loggers;
+
+public interface IInternalEventStorage
+{
+    Task DeleteExpiredEvents(CancellationToken cancellationToken);
+}
+
+public class InternalEventStorage<TDbContext> : IInternalEventStorage where TDbContext : ConsoleDbContext
+{
+    private readonly IDbContextFactory<TDbContext> _dbContextFactory;
+    private readonly IOptions<PlansOptions> _planOptionsConfig;
+    private readonly ISystemClock _systemClock;
+
+    public InternalEventStorage(IDbContextFactory<TDbContext> dbContextFactory,
+        IOptions<PlansOptions> planOptionsConfig,
+        ISystemClock systemClock)
+    {
+        _dbContextFactory = dbContextFactory;
+        _planOptionsConfig = planOptionsConfig;
+        _systemClock = systemClock;
+    }
+
+    public async Task DeleteExpiredEvents(CancellationToken cancellationToken)
+    {
+        _planOptionsConfig.Value.TryGetValue("Enterprise", out var enterprisePlan);
+
+        var retentionDays = enterprisePlan?.EventLoggingRetentionPeriod ?? 7;
+
+        await using var db = await _dbContextFactory.CreateDbContextAsync(cancellationToken);
+        var events = await db.OrganizationEvents
+            .Where(x => x.PerformedAt <= _systemClock.UtcNow.UtcDateTime.AddDays(-retentionDays))
+            .AsNoTracking()
+            .ToListAsync(cancellationToken);
+
+        db.RemoveRange(events);
+        await db.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/Service/EventLog/AddEventLoggingRegistration.cs
+++ b/src/Service/EventLog/AddEventLoggingRegistration.cs
@@ -11,7 +11,8 @@ public static class AddEventLoggingRegistration
             .AddScoped<EventLoggerEfWriteStorage>()
             .AddScoped<IEventLogStorage, EventLoggerEfReadStorage>()
             .AddScoped<IEventLogContext, EventLogContext>()
-            .AddScoped(GetEventLogger);
+            .AddScoped(GetEventLogger)
+            .AddHostedService<EventDeletionBackgroundWorker>();
 
     private static IEventLogger GetEventLogger(IServiceProvider serviceProvider) =>
         serviceProvider.GetRequiredService<IEventLogContext>().Features.EventLoggingIsEnabled

--- a/src/Service/EventLog/EventDeletionBackgroundWorker.cs
+++ b/src/Service/EventLog/EventDeletionBackgroundWorker.cs
@@ -1,0 +1,62 @@
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Passwordless.Common.EventLog.Models;
+using Passwordless.Service.EventLog.Models;
+using Passwordless.Service.Storage.Ef;
+
+namespace Passwordless.Service.EventLog;
+
+public class EventDeletionBackgroundWorker : BackgroundService
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ISystemClock _systemClock;
+    private readonly ILogger<EventDeletionBackgroundWorker> _logger;
+
+    public EventDeletionBackgroundWorker(IServiceProvider serviceProvider, ISystemClock systemClock, ILogger<EventDeletionBackgroundWorker> logger)
+    {
+        _serviceProvider = serviceProvider;
+        _systemClock = systemClock;
+        _logger = logger;
+    }
+
+    protected async override Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("Starting Event Log Deletion Worker");
+
+        using PeriodicTimer timer = new(TimeSpan.FromDays(1));
+
+        try
+        {
+            do
+            {
+                await DeleteExpiredEventLogs(stoppingToken);
+            } while (await timer.WaitForNextTickAsync(stoppingToken));
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogInformation("Event Log Deletion Worker was cancelled.");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Event Log Deletion failed.");
+        }
+    }
+
+    private async Task DeleteExpiredEventLogs(CancellationToken cancellationToken)
+    {
+        using var serviceScope = _serviceProvider.CreateScope();
+        var dbContext = serviceScope.ServiceProvider.GetRequiredService<DbGlobalContext>();
+
+        var query = from feature in dbContext.AppFeatures.Where(x => x.EventLoggingIsEnabled).AsNoTracking()
+            from @event in dbContext.ApplicationEvents
+                .Where(x => x.TenantId == feature.Tenant
+                            && x.PerformedAt <= _systemClock.UtcNow.UtcDateTime.AddDays(feature.EventLoggingRetentionPeriod)).AsNoTracking()
+            select new ApplicationEvent { Id = @event.Id };
+
+        dbContext.RemoveRange(await query.ToListAsync(cancellationToken));
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+}


### PR DESCRIPTION
This PR is two parts.

Part one is deleting expired application event logs from the database that are outside of that tenant's feature expiration record saved in the database.  This occurs as a background task in the API.

Part two is deleting expired organization event logs from the database that are outside of the global organization retention setting from the config.  I had to create another context (`InternalEventLogStorage`) to handle this due to the context factory changes.  This will occur outside the request scope in a background service.