### PR TITLE
Fixing api key on app logs

### DIFF
--- a/src/AdminConsole/EventLog/DTOs/AuditLogResponses.cs
+++ b/src/AdminConsole/EventLog/DTOs/AuditLogResponses.cs
@@ -4,4 +4,4 @@ public record OrganizationEventLogResponse(int OrganizationId, IEnumerable<Event
 
 public record ApplicationEventLogResponse(string TenantId, IEnumerable<EventLogEvent> Events, int TotalEventCount);
 
-public record EventLogEvent(DateTime PerformedAt, string EventType, string Message, string Severity, string PerformedBy, string Subject, string ApiKeyAbbreviated);
+public record EventLogEvent(DateTime PerformedAt, string EventType, string Message, string Severity, string PerformedBy, string Subject, string ApiKeyId);

--- a/src/AdminConsole/Pages/App/Logs/Log.cshtml
+++ b/src/AdminConsole/Pages/App/Logs/Log.cshtml
@@ -61,7 +61,7 @@
                                     @logEvent.EventType
                                 </td>
                                 <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-                                    @(string.IsNullOrEmpty(logEvent.ApiKeyAbbreviated) ? "" : string.Concat("***", logEvent.ApiKeyAbbreviated))
+                                    @(string.IsNullOrEmpty(logEvent.ApiKeyId) ? "" : string.Concat("***", logEvent.ApiKeyId))
                                 </td>
                             </tr>
                         }


### PR DESCRIPTION
There was a mismatch between the api name model and the resposne model. This will make them the same.