### PR TITLE
Use only hash as prerelease version suffix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -118,15 +118,7 @@ jobs:
       - name: Generate prerelease version
         id: prerelease-version
         if: ${{ github.event_name != 'release' }}
-        run: |
-          time=$(date +%s)
-          ref="${{ github.head_ref || github.ref_name }}"
-          
-          ref_clean="$ref"
-          ref_clean="${ref_clean/\//-}"
-          ref_clean="${ref_clean/_/-}"
-          
-          echo "version=0.0.0-ci-$time-$ref_clean" >> $GITHUB_OUTPUT
+        run: echo "version=0.0.0-ci-#{{ github.sha }}" >> $GITHUB_OUTPUT
 
       - name: Publish app
         run: >

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -118,7 +118,7 @@ jobs:
       - name: Generate prerelease version
         id: prerelease-version
         if: ${{ github.event_name != 'release' }}
-        run: echo "version=0.0.0-ci-#{{ github.sha }}" >> $GITHUB_OUTPUT
+        run: echo "version=0.0.0-ci-${{ github.sha }}" >> $GITHUB_OUTPUT
 
       - name: Publish app
         run: >

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -99,7 +99,9 @@ jobs:
   pack:
     strategy:
       matrix:
-        app: [Api, AdminConsole]
+        app:
+          - Api
+          - AdminConsole
 
     runs-on: ubuntu-latest
     permissions:
@@ -139,7 +141,9 @@ jobs:
   deploy:
     strategy:
         matrix:
-          app: [Api, AdminConsole]
+          app:
+            - Api
+            - AdminConsole
 
     environment: devtest-${{ matrix.app }}
     concurrency: devtest-${{ matrix.app }}


### PR DESCRIPTION
As discussed with @abergs.

The original version also used a timestamp to order versions (higher timestamps would appear earlier), but it might not be relevant here as it is in `passwordless-dotnet`.