### PR TITLE
Try to configure DD Version from code

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -166,13 +166,6 @@ jobs:
         with:
           name: ${{ matrix.app }}
           path: ${{ matrix.app }}/
-      
-      # This step is ONLY needed when using the Azure CLI to either set app settings or publish
-      # Might be removed if we don't need to set app settings 
-      # - name: Login to Azure
-      #   uses: Azure/login@1f63701bf3e6892515f1b7ce2d2bf1708b46beaf  # v1.4.3
-      #   with:
-      #     creds: ${{ secrets.APP_SERVICE_SP }}
 
       - name: Push app
         uses: azure/webapps-deploy@145a0687697df1d8a28909569f6e5d86213041f9 # v3.0.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -169,18 +169,11 @@ jobs:
       
       # This step is ONLY needed when using the Azure CLI to either set app settings or publish
       # Might be removed if we don't need to set app settings 
-      - name: Login to Azure
-        uses: Azure/login@1f63701bf3e6892515f1b7ce2d2bf1708b46beaf  # v1.4.3
-        with:
-          creds: ${{ secrets.APP_SERVICE_SP }}
+      # - name: Login to Azure
+      #   uses: Azure/login@1f63701bf3e6892515f1b7ce2d2bf1708b46beaf  # v1.4.3
+      #   with:
+      #     creds: ${{ secrets.APP_SERVICE_SP }}
 
-      # !! Important to pipe send output to  > /dev/null because otherwise all other AppSettings get printed to logs.
-      - name: Set DD_VERSION in Azure        
-        run: |
-          az webapp config appsettings set -g ${{ secrets.AZURE_RESOURCE_GROUP_NAME }} \
-          -n ${{ secrets.AZURE_APP_NAME }} --slot staging \
-          --settings DD_VERSION=${{ steps.prerelease-version.outputs.version }} > /dev/null
-    
       - name: Push app
         uses: azure/webapps-deploy@145a0687697df1d8a28909569f6e5d86213041f9 # v3.0.0
         with: 

--- a/src/AdminConsole/Program.cs
+++ b/src/AdminConsole/Program.cs
@@ -1,4 +1,3 @@
-using System.Reflection;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.Extensions.Options;

--- a/src/AdminConsole/Program.cs
+++ b/src/AdminConsole/Program.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Datadog.Trace;
 using Datadog.Trace.Configuration;
 using Microsoft.AspNetCore.Authorization;
@@ -17,6 +18,7 @@ using Passwordless.AdminConsole.Services.Mail;
 using Passwordless.AdminConsole.Services.PasswordlessManagement;
 using Passwordless.AspNetCore;
 using Passwordless.Common.Configuration;
+using Passwordless.Common.Extensions;
 using Passwordless.Common.Middleware.SelfHosting;
 using Passwordless.Common.Services.Mail;
 using Serilog;
@@ -70,6 +72,7 @@ void RunTheApp()
         IConfigurationSection ddConfig = ctx.Configuration.GetSection("Datadog");
         if (ddConfig.Exists())
         {
+            var assembly = Assembly.GetExecutingAssembly();
             var version = assembly.GetInformationalVersion() ??
                               assembly.GetName().Version?.ToString() ??
                               "unknown version"; // 1.2.3-ci-SHA

--- a/src/AdminConsole/Program.cs
+++ b/src/AdminConsole/Program.cs
@@ -1,4 +1,3 @@
-using System.Reflection;
 using Datadog.Trace;
 using Datadog.Trace.Configuration;
 using Microsoft.AspNetCore.Authorization;
@@ -74,7 +73,7 @@ void RunTheApp()
             var version = assembly.GetInformationalVersion() ??
                               assembly.GetName().Version?.ToString() ??
                               "unknown version"; // 1.2.3-ci-SHA
-            
+
             // TRY TO GET DataDog Azure App Service Extension to use a version configured from code
             // instead of DD_VERSION environment variable
             // Doesn't seem to work though? 

--- a/src/AdminConsole/datadog.json
+++ b/src/AdminConsole/datadog.json
@@ -1,0 +1,6 @@
+{
+    "DD_SITE": "datadoghq.eu",
+    "DD_ENV": "pass-any",
+    "DD_VERSION": "0.0.0",
+    "DD_LOGS_INJECTION": true
+}

--- a/src/Api/Program.cs
+++ b/src/Api/Program.cs
@@ -156,13 +156,13 @@ if (isSelfHosted)
 app.UseCors("default");
 app.UseSecurityHeaders();
 app.UseStaticFiles();
-app.UseMiddleware<EventLogStorageCommitMiddleware>();
 app.UseAuthentication();
 app.UseAuthorization();
 app.UseMiddleware<AcceptHeaderMiddleware>();
 app.UseMiddleware<LoggingMiddleware>();
 app.UseSerilogRequestLogging();
 app.UseMiddleware<EventLogContextMiddleware>();
+app.UseMiddleware<EventLogStorageCommitMiddleware>();
 app.UseMiddleware<FriendlyExceptionsMiddleware>();
 app.MapSigninEndpoints();
 app.MapRegisterEndpoints();

--- a/src/Api/Program.cs
+++ b/src/Api/Program.cs
@@ -1,4 +1,7 @@
+using System.Reflection;
 using System.Text.Json;
+using Datadog.Trace;
+using Datadog.Trace.Configuration;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.EntityFrameworkCore;
 using Passwordless.Api;
@@ -18,6 +21,12 @@ using Passwordless.Service.Mail;
 using Passwordless.Service.Storage.Ef;
 using Serilog;
 using Serilog.Sinks.Datadog.Logs;
+
+// Set Datadog version tag through an environment variable, as it's the only way to set it apparently
+Environment.SetEnvironmentVariable(
+    "DD_VERSION",
+    Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "unknown"
+);
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
@@ -44,15 +53,24 @@ builder.Host.UseSerilog((ctx, sp, config) =>
         config.WriteTo.Seq("http://localhost:5341");
     }
 
+    var version = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "unknown";
+
     IConfigurationSection ddConfig = ctx.Configuration.GetSection("Datadog");
     if (ddConfig.Exists())
     {
+        // setup tracing
+        var settings = TracerSettings.FromDefaultSources();
+        settings.ServiceVersion = version;
+        Tracer.Configure(settings);
+
         // setup serilog logging
         var apiKey = ddConfig.GetValue<string>("ApiKey");
         if (!string.IsNullOrEmpty(apiKey))
         {
             config.WriteTo.DatadogLogs(
                 ddConfig.GetValue<string>("ApiKey"),
+                tags: new[] { "version:" + version },
+                service: "pass-api",
                 configuration: new DatadogConfiguration(ddConfig.GetValue<string>("url")));
         }
     }

--- a/src/Api/Program.cs
+++ b/src/Api/Program.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using System.Text.Json;
 using Datadog.Trace;
 using Datadog.Trace.Configuration;
@@ -10,6 +11,7 @@ using Passwordless.Api.HealthChecks;
 using Passwordless.Api.Helpers;
 using Passwordless.Api.Middleware;
 using Passwordless.Common.Configuration;
+using Passwordless.Common.Extensions;
 using Passwordless.Common.Middleware.SelfHosting;
 using Passwordless.Common.Services.Mail;
 using Passwordless.Common.Utils;
@@ -51,7 +53,7 @@ builder.Host.UseSerilog((ctx, sp, config) =>
     IConfigurationSection ddConfig = ctx.Configuration.GetSection("Datadog");
     if (ddConfig.Exists())
     {
-
+        var assembly = Assembly.GetExecutingAssembly();
         var version = assembly.GetInformationalVersion() ??
                               assembly.GetName().Version?.ToString() ??
                               "unknown version";

--- a/src/Api/Program.cs
+++ b/src/Api/Program.cs
@@ -1,4 +1,3 @@
-using System.Reflection;
 using System.Text.Json;
 using Datadog.Trace;
 using Datadog.Trace.Configuration;
@@ -47,7 +46,7 @@ builder.Host.UseSerilog((ctx, sp, config) =>
         config.WriteTo.Seq("http://localhost:5341");
     }
 
-    
+
 
     IConfigurationSection ddConfig = ctx.Configuration.GetSection("Datadog");
     if (ddConfig.Exists())
@@ -70,7 +69,7 @@ builder.Host.UseSerilog((ctx, sp, config) =>
         {
             config.WriteTo.DatadogLogs(
                 ddConfig.GetValue<string>("ApiKey"),
-                tags: new[] { "version:" + version },        
+                tags: new[] { "version:" + version },
                 configuration: new DatadogConfiguration(ddConfig.GetValue<string>("url")));
         }
     }

--- a/src/Api/Program.cs
+++ b/src/Api/Program.cs
@@ -1,4 +1,3 @@
-using System.Reflection;
 using System.Text.Json;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.EntityFrameworkCore;

--- a/src/Api/Program.cs
+++ b/src/Api/Program.cs
@@ -20,12 +20,6 @@ using Passwordless.Service.Storage.Ef;
 using Serilog;
 using Serilog.Sinks.Datadog.Logs;
 
-// Set Datadog version tag through an environment variable, as it's the only way to set it apparently
-Environment.SetEnvironmentVariable(
-    "DD_VERSION",
-    Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "unknown"
-);
-
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
 bool isSelfHosted = builder.Configuration.GetValue<bool>("SelfHosted");

--- a/src/Api/datadog.json
+++ b/src/Api/datadog.json
@@ -1,0 +1,6 @@
+{
+    "DD_SITE": "datadoghq.eu",
+    "DD_ENV": "pass-any",
+    "DD_VERSION": "0.0.0",
+    "DD_LOGS_INJECTION": true
+}


### PR DESCRIPTION
We currently utilize DD for monitoring logs, traces, deployments etc.

A essential feature is the version-tagging offered by DataDog to discover regressions and perf differences between deployments. 

This PR tries to move the responsibility of providing the version value away from the environment variable `DD_VERSION` towards code configuration.

**Motivation:** Configuring the DD_VERSION environment variable makes deployment complex and brittle, and out of sync (Actual code version might not be same as ENV variable)

**Problem:** Configuring the Version this way does not work -- Data Dogs UI indicates we no longer provide a version together with the logs.

Note: We're using the Azure App Service DataDog Extension.
Note 2: We would like to move towards OpenTelemetry where possible.