### PR TITLE
Fix use case where credentials are generated with credProtect 3

### DIFF
--- a/src/Service/Fido2ServiceEndpoints.cs
+++ b/src/Service/Fido2ServiceEndpoints.cs
@@ -289,7 +289,10 @@ public class Fido2ServiceEndpoints : IFido2Service
         }
 
         // Create options
-        var uv = string.IsNullOrEmpty(request.UserVerification) ? UserVerificationRequirement.Discouraged : request.UserVerification.ToEnum<UserVerificationRequirement>();
+        UserVerificationRequirement? uv = string.IsNullOrEmpty(request.UserVerification)
+            ? null
+            : request.UserVerification.ToEnum<UserVerificationRequirement>();
+
         var options = fido2.GetAssertionOptions(
             existingCredentials,
             uv


### PR DESCRIPTION
The authenticator would default to 'preferred' anyways when userVerification is null.