### PR TITLE
Make docker deployments repo-agnostic

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -90,6 +90,6 @@ jobs:
           --file ${{ matrix.dockerfile }}
           --platform linux/amd64,linux/arm64
           --push
-          --tag ghcr.io/passwordless/${{ matrix.name }}:latest
-          ${{ github.event_name == 'release' && format('--tag ghcr.io/passwordless/{0}:{1}', matrix.name, github.ref_name) || '' }}
-          ${{ github.event_name == 'release' && format('--tag ghcr.io/passwordless/{0}:stable', matrix.name) || '' }}
+          --tag ghcr.io/${{ github.repository_owner }}/${{ matrix.name }}:latest
+          ${{ github.event_name == 'release' && format('--tag ghcr.io/{0}/{1}:{2}', github.repository_owner, matrix.name, github.ref_name) || '' }}
+          ${{ github.event_name == 'release' && format('--tag ghcr.io/{0}/{1}:stable', github.repository_owner, matrix.name) || '' }}


### PR DESCRIPTION
Currently, docker images are tagged as `ghcr.io/passwordless/image:tag`. This will break when we move from the `passwordless` org to `bitwarden`, since the namespace will be different. This change removes static references to the org name and replaces them with dynamic ones.