### PR TITLE
WIP

### DIFF
--- a/rebuild.sh
+++ b/rebuild.sh
@@ -1,0 +1,4 @@
+docker stop pass
+docker rm pass
+docker build . -f self-host/Dockerfile -t bitwarden/passwordless
+docker run --name pass -p 5701:5701 bitwarden/passwordless

--- a/self-host/Dockerfile
+++ b/self-host/Dockerfile
@@ -69,8 +69,9 @@ ENV BWP_ENABLE_API=true
 ENV BWP_DB_FILE_API="/etc/bitwarden_passwordless/api.db"
 ENV BWP_DB_FILE_ADMIN="/etc/bitwarden_passwordless/admin.db"
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
-ENV Passwordless_ApiUrl="http://localhost:5000"
-ENV PasswordlessManagement_ApiUrl="http://localhost:5000"
+ENV Passwordless__ApiUrl="http://localhost:5701/api"
+ENV PasswordlessManagement__ApiUrl="http://localhost:5701/api"
+ENV PasswordlessManagement__InternalApiUrl="http://localhost:5000"
 ENV SelfHosted=true
 
 # Add packages

--- a/self-host/entrypoint.sh
+++ b/self-host/entrypoint.sh
@@ -81,8 +81,9 @@ fi
 #########################
 # Internal & Public Url #
 #########################
-export Passwordless__ApiUrl=$PasswordlessManagement_ApiUrl
-export PasswordlessManagement__ApiUrl=$PasswordlessManagement_ApiUrl
+export Passwordless__ApiUrl=$Passwordless__ApiUrl
+export PasswordlessManagement__ApiUrl=$PasswordlessManagement__ApiUrl
+export PasswordlessManagement__InternalApiUrl=$PasswordlessManagement__InternalApiUrl
 
 if [ "$BWP_DOMAIN" = "localhost" ] && [ "$BWP_ENABLE_SSL" != "false" ]; then
   echo "[Configuration] ERROR: Set environment variable 'BWP_ENABLE_SSL' to 'true' when 'BWP_DOMAIN' is not 'localhost'.";
@@ -102,9 +103,10 @@ if [ "$BWP_PORT" == "null" ]; then
   exit 1; 
 fi
 
-export PasswordlessManagement__InternalApiUrl="$scheme://${BWP_DOMAIN:-localhost}:${BWP_PORT:-5701}/api";
-echo "[Configuration] API private: $PasswordlessManagement__ApiUrl";
-echo "[Configuration] API public: $PasswordlessManagement__InternalApiUrl";
+#export PasswordlessManagement__InternalApiUrl="$scheme://${BWP_DOMAIN:-localhost}:${BWP_PORT:-5701}/api";
+echo "[Configuration] API Management Url: $PasswordlessManagement__ApiUrl";
+echo "[Configuration] API Internal Management Url: $PasswordlessManagement__InternalApiUrl";
+echo "[Configuration] Passwordless Api Url: $Passwordless__ApiUrl";
 
 ##############################################
 # Generate ApiKey, ApiSecret & ManagementKey #

--- a/src/AdminConsole/Pages/Account/Profile.cshtml.cs
+++ b/src/AdminConsole/Pages/Account/Profile.cshtml.cs
@@ -3,17 +3,18 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Passwordless.AdminConsole.Identity;
 using Passwordless.AdminConsole.Pages.Shared;
+using Passwordless.AdminConsole.Services;
 using Passwordless.AdminConsole.Services.AuthenticatorData;
 
 namespace Passwordless.AdminConsole.Pages.Account;
 
 public class Profile : PageModel
 {
-    private readonly IPasswordlessClient _client;
+    private readonly IScopedPasswordlessClient _client;
     private readonly UserManager<ConsoleAdmin> _userManager;
 
     public Profile(
-        IPasswordlessClient client,
+        IScopedPasswordlessClient client,
         UserManager<ConsoleAdmin> userManager,
         IAuthenticatorDataProvider authenticatorDataProvider)
     {

--- a/src/AdminConsole/Services/PasswordlessManagement/PasswordlessManagementBootstrap.cs
+++ b/src/AdminConsole/Services/PasswordlessManagement/PasswordlessManagementBootstrap.cs
@@ -22,7 +22,7 @@ public static class PasswordlessManagementBootstrap
         builder.Services.AddHttpClient<IPasswordlessManagementClient, PasswordlessManagementClient>((sp, client) =>
         {
             var options = sp.GetRequiredService<IOptions<PasswordlessManagementOptions>>().Value;
-
+            
             client.BaseAddress = new Uri(options.InternalApiUrl);
             client.DefaultRequestHeaders.Add("ManagementKey", options.ManagementKey);
         });

--- a/src/AdminConsole/Services/ScopedPasswordlessClient.cs
+++ b/src/AdminConsole/Services/ScopedPasswordlessClient.cs
@@ -20,12 +20,13 @@ public class ScopedPasswordlessClient : PasswordlessClient, IScopedPasswordlessC
         : base(new PasswordlessOptions
         {
             ApiSecret = context.ApiSecret,
-            ApiUrl = options.Value.ApiUrl,
+            ApiUrl = "http://localhost:5000",
             ApiKey = options.Value.ApiKey
         })
     {
         _client = httpClient;
 
+        
         // can be dropped
         _client.DefaultRequestHeaders.Remove("ApiSecret");
         _client.DefaultRequestHeaders.Add("ApiSecret", context.ApiSecret);

--- a/src/AdminConsole/appsettings.json
+++ b/src/AdminConsole/appsettings.json
@@ -110,5 +110,9 @@
   },
   "Datadog": {
     "url": "https://http-intake.logs.datadoghq.eu"
+  },
+  "SelfHosted": true,
+  "PasswordlessManagement": {
+    "InternalApiUrl": "http://localhost:5000"
   }
 }


### PR DESCRIPTION
This PR contains fixes to make `docker run --name pass -p 5701:5701 bitwarden/passwordless` work.

Tip when working on this branch, run the `rebuild.sh`-script to make stuff work.

Working

* Creating an app.
* Playground get token

Not working:

* Playground create passkey
* AccountSettings, invalid ApiSecret
* Relies on a hardcoded ApiUrl

Loose thoughts: Do we really need to set the ENV variables or can we use configuration from appsettings files?

Different cases:

* The browser needs a ApiUrl that is "external": `http://localhost:5701/api`
* The AdminConsole needs a InternalApiUrl to create/list Admin Passkeys: `http://localhost:5000`
* The AdminConsole needs a InternalApiUrl for management of apps: `http://localhost:5000`
* The AdminConsole needs a InternalApiUrl to create/list Playground Passkeys: `http://localhost:5000`