### PR TITLE
CVE-2024-0057

### DIFF
--- a/src/AdminConsole/AdminConsole.csproj
+++ b/src/AdminConsole/AdminConsole.csproj
@@ -21,7 +21,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.0" />
     <PackageReference Include="Passwordless.AspNetCore" Version="2.0.0-beta7" />
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />

--- a/src/AdminConsole/Helpers/RazorPageHtmlExtensions.cs
+++ b/src/AdminConsole/Helpers/RazorPageHtmlExtensions.cs
@@ -1,11 +1,10 @@
 using System.Text.Encodings.Web;
+using System.Text.Json;
 using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc.Razor;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
-using Newtonsoft.Json;
-using NuGet.Protocol;
 
 namespace Passwordless.AdminConsole.Helpers;
 
@@ -23,7 +22,7 @@ public static class RazorPageHtmlExtensions
         }
 
         nonce ??= (html.ViewContext.HttpContext?.Items["csp-nonce"])?.ToString();
-        var script = $"<script type=\"importmap\" nonce={nonce}>\n{imports.ToJson(Formatting.Indented)}\n</script>";
+        var script = $"<script type=\"importmap\" nonce={nonce}>\n{JsonSerializer.Serialize(imports)}\n</script>";
         return html.Raw(script);
     }
 


### PR DESCRIPTION
### Ticket

n/a

### Description

A security feature bypass vulnerability exists when Microsoft .NET Framework-based applications use X.509 chain building APIs but do not completely validate the X.509 certificate due to a logic flaw. An attacker could present an arbitrary untrusted certificate with malformed signatures, triggering a bug in the framework. The framework will correctly report that X.509 chain building failed, but it will return an incorrect reason code for the failure. Applications which utilize this reason code to make their own chain building trust decisions may inadvertently treat this scenario as a successful chain build. This could allow an adversary to subvert the app's typical authentication logic.

It appears we may not need this dependency. Since we're already on 8.0.101, we're not affected otherwise once the dependency is dropped.

### Shape

n/a

### Screenshots

n/a

### Checklist

I did the following to ensure that my changes were tested thoroughly:
- __

I did the following to ensure that my changes do not introduce security vulnerabilities:
- __
