### PR TITLE
CVE-2022-26907

### DIFF
--- a/src/AdminConsole/AdminConsole.csproj
+++ b/src/AdminConsole/AdminConsole.csproj
@@ -5,9 +5,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Extensions.AspNetCore.DataProtection.Keys" Version="1.2.3" />
     <PackageReference Include="Azure.Identity" Version="1.10.4" />
     <PackageReference Include="Datadog.Trace" Version="2.41.0" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.AzureKeyVault" Version="3.1.24" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="8.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.1" />


### PR DESCRIPTION
### Ticket

- CVE-2022-26907

### Description

This vulnerability could disclose sensitive information in exception body, which might include user access tokens. Successful exploitation of this vulnerability requires an attacker to have access to the location where the application that is using the SDK is storing the exception (for example, event logs).

### Shape

The old library was deprecated some time ago.

### Screenshots

n/a

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- __

I did the following to ensure that my changes do not introduce security vulnerabilities:
- __
