### PR TITLE
Apex Charts to 4.7.0

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,6 +14,11 @@
       "matchUpdateTypes": ["minor", "patch"]
     },
     {
+      "groupName": "ApexCharts",
+      "matchPackageNames": ["apexcharts"],
+      "allowedVersions": "<5.0.0"
+    },
+    {
       "groupName": "nuget minor",
       "matchManagers": ["nuget"],
       "matchUpdateTypes": ["minor", "patch"]

--- a/src/AdminConsole/package-lock.json
+++ b/src/AdminConsole/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@passwordlessdev/passwordless-client": "1.2.2",
-        "apexcharts": "5.3.4",
+        "apexcharts": "4.7.0",
         "es-module-shims": "2.0.9",
         "vue": "3.5.13"
       },
@@ -470,10 +470,10 @@
       }
     },
     "node_modules/apexcharts": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/apexcharts/-/apexcharts-5.3.4.tgz",
-      "integrity": "sha512-N0gNh8uLu/BN8N+BCphNK+gZAoSoUtDDn1jFGB+3+EMcv8s6vajuP3W0g4dMLTRp6chFkjMmQK3uD8pz4ISmLA==",
-      "license": "SEE LICENSE IN LICENSE",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/apexcharts/-/apexcharts-4.7.0.tgz",
+      "integrity": "sha512-iZSrrBGvVlL+nt2B1NpqfDuBZ9jX61X9I2+XV0hlYXHtTwhwLTHDKGXjNXAgFBDLuvSYCB/rq2nPWVPRv2DrGA==",
+      "license": "MIT",
       "dependencies": {
         "@svgdotjs/svg.draggable.js": "^3.0.4",
         "@svgdotjs/svg.filter.js": "^3.0.8",

--- a/src/AdminConsole/package.json
+++ b/src/AdminConsole/package.json
@@ -12,7 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "@passwordlessdev/passwordless-client": "1.2.2",
-    "apexcharts": "5.3.4",
+    "apexcharts": "4.7.0",
     "es-module-shims": "2.0.9",
     "vue": "3.5.13"
   },


### PR DESCRIPTION
### Description
This locks apex charts npm library to <5.0. It will be currently set to 4.7. This is due to a licensing change.

### Shape
<!--
    Give a high-level overview of the technical design involved in the implemented changes.
    If the changes don't have any architectural impact, you can remove this section.
-->

### Screenshots
<!--
    Include any relevant UI screenshots showcasing the before & after of your changes.
    If the changes don't have any UI impact, you can remove this section.
-->

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- __

I did the following to ensure that my changes do not introduce security vulnerabilities:
- __
