### PR TITLE
Fix MessagePack.Analyzer dependency version

### DIFF
--- a/src/Service/Service.csproj
+++ b/src/Service/Service.csproj
@@ -6,7 +6,7 @@
     <PackageReference Include="Fido2.Models" Version="4.0.0" />
     <PackageReference Include="Humanizer.Core" Version="3.0.1" />
     <PackageReference Include="MessagePack" Version="3.1.7" />
-    <PackageReference Include="MessagePackAnalyzer" Version="3.1.4">
+    <PackageReference Include="MessagePackAnalyzer" Version="3.1.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
### Description

After #858 was merged as a security dependency, the build started failing because while the `MessagePack` dependency was upgraded to 3.1.7, the `MessagePackAnalyzer` package was not upgraded with it. `MessagePack` relies on this specific version of the package, which this PR updates.
